### PR TITLE
Refactor out styled components from render methods

### DIFF
--- a/components/Button/Button.stories.tsx
+++ b/components/Button/Button.stories.tsx
@@ -44,7 +44,7 @@ stories
   .add("Simple primary with text", () => (
     <Button
       label={text("Label", "Button")}
-      kind={select("Kind", typeOptions, "primary")}
+      type={select("Type", typeOptions, "primary")}
       size={select("Size", sizeOptions, "medium")}
       colorTheme={select("Color theme", colorThemeOptions, "neutral")}
       ghost={boolean("Ghost", false)}
@@ -56,7 +56,7 @@ stories
   .add("Simple secondary with text", () => (
     <Button
       label={text("Label", "Button")}
-      kind={select("Kind", typeOptions, "secondary")}
+      type={select("Type", typeOptions, "secondary")}
       size={select("Size", sizeOptions, "medium")}
       colorTheme={select("Color theme", colorThemeOptions, "neutral")}
       ghost={boolean("Ghost", false)}
@@ -68,7 +68,7 @@ stories
   .add("Ghost (inverted color scheme)", () => (
     <Button
       label={text("Label", "Button")}
-      kind={select("Kind", typeOptions, "primary")}
+      type={select("Type", typeOptions, "primary")}
       size={select("Size", sizeOptions, "medium")}
       colorTheme={select("Color theme", colorThemeOptions, "neutral")}
       ghost={boolean("Ghost", true)}
@@ -80,7 +80,7 @@ stories
   .add("With an inset", () => (
     <Button
       label={text("Label", "Button")}
-      kind={select("Kind", typeOptions, "primary")}
+      type={select("Type", typeOptions, "primary")}
       size={select("Size", sizeOptions, "medium")}
       colorTheme={select("Color theme", colorThemeOptions, "neutral")}
       ghost={boolean("Ghost", false)}

--- a/components/Button/Button.stories.tsx
+++ b/components/Button/Button.stories.tsx
@@ -44,7 +44,7 @@ stories
   .add("Simple primary with text", () => (
     <Button
       label={text("Label", "Button")}
-      type={select("Type", typeOptions, "primary")}
+      kind={select("Kind", typeOptions, "primary")}
       size={select("Size", sizeOptions, "medium")}
       colorTheme={select("Color theme", colorThemeOptions, "neutral")}
       ghost={boolean("Ghost", false)}
@@ -56,7 +56,7 @@ stories
   .add("Simple secondary with text", () => (
     <Button
       label={text("Label", "Button")}
-      type={select("Type", typeOptions, "primary")}
+      kind={select("Kind", typeOptions, "secondary")}
       size={select("Size", sizeOptions, "medium")}
       colorTheme={select("Color theme", colorThemeOptions, "neutral")}
       ghost={boolean("Ghost", false)}
@@ -68,7 +68,7 @@ stories
   .add("Ghost (inverted color scheme)", () => (
     <Button
       label={text("Label", "Button")}
-      type={select("Type", typeOptions, "primary")}
+      kind={select("Kind", typeOptions, "primary")}
       size={select("Size", sizeOptions, "medium")}
       colorTheme={select("Color theme", colorThemeOptions, "neutral")}
       ghost={boolean("Ghost", true)}
@@ -80,7 +80,7 @@ stories
   .add("With an inset", () => (
     <Button
       label={text("Label", "Button")}
-      type={select("Type", typeOptions, "primary")}
+      kind={select("Kind", typeOptions, "primary")}
       size={select("Size", sizeOptions, "medium")}
       colorTheme={select("Color theme", colorThemeOptions, "neutral")}
       ghost={boolean("Ghost", false)}

--- a/components/Button/ButtonWrapper.tsx
+++ b/components/Button/ButtonWrapper.tsx
@@ -31,7 +31,7 @@ interface ButtonWrapperProps {
   /** The text label to be shown on the button */
   label?: string
   /** Indicates the importance of the button's actions */
-  kind?: "primary" | "secondary"
+  type?: "primary" | "secondary"
   /** Indicates the state of an action. Can be a preset string or an object
    * representing custom color theme that overrides the defaults,
    * The color theme should be passed in the form of an object containing two properties,
@@ -89,7 +89,7 @@ const parseColorTheme = colorTheme => {
 
 const ButtonWrapper: React.FC<ButtonWrapperProps> = ({
   label,
-  kind,
+  type,
   ghost,
   size,
   disabled,
@@ -115,7 +115,7 @@ const ButtonWrapper: React.FC<ButtonWrapperProps> = ({
       customProps={{
         label,
         icon,
-        kind,
+        type,
         ghost,
         size,
         bare,
@@ -145,7 +145,7 @@ const ButtonWrapper: React.FC<ButtonWrapperProps> = ({
 }
 
 ButtonWrapper.defaultProps = {
-  kind: "primary",
+  type: "primary",
   colorTheme: DEFAULT_COLOR_THEME,
   ghost: false,
   disabled: false,

--- a/components/Button/ButtonWrapper.tsx
+++ b/components/Button/ButtonWrapper.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import React, { SyntheticEvent } from "react"
 import Icon from "../Icon"
 import * as theme from "../styles/variables"
 import chroma from "chroma-js"
@@ -31,7 +31,7 @@ interface ButtonWrapperProps {
   /** The text label to be shown on the button */
   label?: string
   /** Indicates the importance of the button's actions */
-  type?: "primary" | "secondary"
+  kind?: "primary" | "secondary"
   /** Indicates the state of an action. Can be a preset string or an object
    * representing custom color theme that overrides the defaults,
    * The color theme should be passed in the form of an object containing two properties,
@@ -89,7 +89,7 @@ const parseColorTheme = colorTheme => {
 
 const ButtonWrapper: React.FC<ButtonWrapperProps> = ({
   label,
-  type,
+  kind,
   ghost,
   size,
   disabled,
@@ -112,36 +112,40 @@ const ButtonWrapper: React.FC<ButtonWrapperProps> = ({
 
   return (
     <ButtonBase
-      label={label}
-      icon={icon}
-      type={type!}
-      ghost={ghost!}
-      size={size!}
-      disabled={disabled}
-      onClick={e =>
+      customProps={{
+        label,
+        icon,
+        kind,
+        ghost,
+        size,
+        bare,
+        colorTheme: parsedColorTheme,
+        fontSize: baseFontSize,
+        lineHeight: baseLineHeight,
+      }}
+      onClick={(e: SyntheticEvent) =>
         (onClick && onClick(e)) || (href && window.location.assign(href))
       }
-      bare={bare!}
-      colorTheme={parsedColorTheme}
-      fontSize={baseFontSize}
-      lineHeight={baseLineHeight}>
+      disabled={disabled}>
       {icon ? <Icon type={icon} /> : null}
       {label}
       {insetLabel ? (
         <ButtonInset
-          label={insetLabel}
-          backgroundColor={parsedColorTheme.insetBackground}
-          fontColor={parsedColorTheme.insetFont}
-          fontSize={`${insetFontSize}rem`}
-          lineHeight={`${insetLineHeight}rem`}
-        />
+          customProps={{
+            backgroundColor: parsedColorTheme.insetBackground,
+            fontColor: parsedColorTheme.insetFont,
+            fontSize: `${insetFontSize}rem`,
+            lineHeight: `${insetLineHeight}rem`,
+          }}>
+          {insetLabel}
+        </ButtonInset>
       ) : null}
     </ButtonBase>
   )
 }
 
 ButtonWrapper.defaultProps = {
-  type: "primary",
+  kind: "primary",
   colorTheme: DEFAULT_COLOR_THEME,
   ghost: false,
   disabled: false,

--- a/components/Button/__tests__/Button.test.jsx
+++ b/components/Button/__tests__/Button.test.jsx
@@ -1,6 +1,7 @@
 import React from "react"
 import Button from "../index"
 import { render, cleanup, fireEvent } from "react-testing-library"
+import { ThemeProvider } from "../../styles"
 import "jest-styled-components"
 import "jest-dom/extend-expect"
 
@@ -13,34 +14,46 @@ describe("Button", () => {
   sizes.forEach(size => {
     describe(`with size ${size}`, () => {
       it("renders a primary variant with a label correctly", () => {
-        const { asFragment } = render(<Button label="button" size={size} />)
+        const { asFragment } = render(
+          <ThemeProvider>
+            <Button label="button" size={size} />
+          </ThemeProvider>
+        )
         expect(asFragment()).toMatchSnapshot()
       })
 
       it("renders a ghost variant correctly", () => {
         const { asFragment } = render(
-          <Button label="button" size={size} ghost />
+          <ThemeProvider>
+            <Button label="button" size={size} ghost />
+          </ThemeProvider>
         )
         expect(asFragment()).toMatchSnapshot()
       })
 
       it("renders a bare variant correctly", () => {
         const { asFragment } = render(
-          <Button label="button" size={size} bare />
+          <ThemeProvider>
+            <Button label="button" size={size} bare />
+          </ThemeProvider>
         )
         expect(asFragment()).toMatchSnapshot()
       })
 
       it("renders with an icon correctly", () => {
         const { asFragment } = render(
-          <Button label="button" size={size} icon="oInfo" />
+          <ThemeProvider>
+            <Button label="button" size={size} icon="oInfo" />
+          </ThemeProvider>
         )
         expect(asFragment()).toMatchSnapshot()
       })
 
       it("renders with a bare icon correctly", () => {
         const { asFragment } = render(
-          <Button label="button" size={size} icon="oInfo" bare />
+          <ThemeProvider>
+            <Button label="button" size={size} icon="oInfo" bare />
+          </ThemeProvider>
         )
         expect(asFragment()).toMatchSnapshot()
       })
@@ -48,43 +61,53 @@ describe("Button", () => {
 
     it("renders with inset correctly", () => {
       const { asFragment } = render(
-        <Button label="button" size={size} insetLabel={"10"} />
+        <ThemeProvider>
+          <Button label="button" size={size} insetLabel={"10"} />
+        </ThemeProvider>
       )
       expect(asFragment()).toMatchSnapshot()
     })
 
     it("renders with text and an icon correctly", () => {
       const { asFragment } = render(
-        <Button label="button" size={size} icon="oInfo" />
+        <ThemeProvider>
+          <Button label="button" size={size} icon="oInfo" />
+        </ThemeProvider>
       )
       expect(asFragment()).toMatchSnapshot()
     })
 
     it("renders with text, icon and inset correctly", () => {
       const { asFragment } = render(
-        <Button label="button" size={size} icon="oInfo" insetLabel={"10"} />
+        <ThemeProvider>
+          <Button label="button" size={size} icon="oInfo" insetLabel={"10"} />
+        </ThemeProvider>
       )
       expect(asFragment()).toMatchSnapshot()
     })
 
     it("renders with a specified color preset corretly", () => {
       const { asFragment } = render(
-        <Button label="button" colorTheme="danger" />
+        <ThemeProvider>
+          <Button label="button" colorTheme="danger" />
+        </ThemeProvider>
       )
       expect(asFragment()).toMatchSnapshot()
     })
 
     it("renders with a custom color theme correctly", () => {
       const { asFragment } = render(
-        <Button
-          label="button"
-          colorTheme={{
-            background: "#f142f4",
-            font: "#f4f141",
-            insetBackground: "#000000",
-            insetFont: "#FFFFFF",
-          }}
-        />
+        <ThemeProvider>
+          <Button
+            label="button"
+            colorTheme={{
+              background: "#f142f4",
+              font: "#f4f141",
+              insetBackground: "#000000",
+              insetFont: "#FFFFFF",
+            }}
+          />
+        </ThemeProvider>
       )
       expect(asFragment()).toMatchSnapshot()
     })
@@ -92,7 +115,11 @@ describe("Button", () => {
 
   it("should call the provided onClick function", () => {
     const onClick = jest.fn()
-    const { getByText } = render(<Button label="button" onClick={onClick} />)
+    const { getByText } = render(
+      <ThemeProvider>
+        <Button label="button" onClick={onClick} />
+      </ThemeProvider>
+    )
     fireEvent.click(getByText("button"))
     expect(onClick).toBeCalled()
     expect(onClick.mock.calls[0].length).toBe(1)
@@ -100,7 +127,11 @@ describe("Button", () => {
 
   it("should navigate to the given href location when provided", () => {
     window.location.assign = jest.fn()
-    const { getByText } = render(<Button label="button" href="/sample" />)
+    const { getByText } = render(
+      <ThemeProvider>
+        <Button label="button" href="/sample" />
+      </ThemeProvider>
+    )
     fireEvent.click(getByText("button"))
     expect(window.location.assign).toBeCalledWith("/sample")
   })

--- a/components/Button/__tests__/__snapshots__/Button.test.jsx.snap
+++ b/components/Button/__tests__/__snapshots__/Button.test.jsx.snap
@@ -25,11 +25,11 @@ exports[`Button renders with a custom color theme correctly 1`] = `
   border: 1px solid #00000000;
 }
 
-.c0 svg {
+.c0 span {
   margin-right: 0rem;
 }
 
-.c0 svg path {
+.c0 span svg path {
   fill: #f4f141;
 }
 
@@ -92,11 +92,11 @@ exports[`Button renders with a custom color theme correctly 2`] = `
   border: 1px solid #00000000;
 }
 
-.c0 svg {
+.c0 span {
   margin-right: 0rem;
 }
 
-.c0 svg path {
+.c0 span svg path {
   fill: #f4f141;
 }
 
@@ -159,11 +159,11 @@ exports[`Button renders with a custom color theme correctly 3`] = `
   border: 1px solid #00000000;
 }
 
-.c0 svg {
+.c0 span {
   margin-right: 0rem;
 }
 
-.c0 svg path {
+.c0 span svg path {
   fill: #f4f141;
 }
 
@@ -226,11 +226,11 @@ exports[`Button renders with a specified color preset corretly 1`] = `
   border: 1px solid #00000000;
 }
 
-.c0 svg {
+.c0 span {
   margin-right: 0rem;
 }
 
-.c0 svg path {
+.c0 span svg path {
   fill: #ffffff;
 }
 
@@ -293,11 +293,11 @@ exports[`Button renders with a specified color preset corretly 2`] = `
   border: 1px solid #00000000;
 }
 
-.c0 svg {
+.c0 span {
   margin-right: 0rem;
 }
 
-.c0 svg path {
+.c0 span svg path {
   fill: #ffffff;
 }
 
@@ -360,11 +360,11 @@ exports[`Button renders with a specified color preset corretly 3`] = `
   border: 1px solid #00000000;
 }
 
-.c0 svg {
+.c0 span {
   margin-right: 0rem;
 }
 
-.c0 svg path {
+.c0 span svg path {
   fill: #ffffff;
 }
 
@@ -427,11 +427,11 @@ exports[`Button renders with inset correctly 1`] = `
   border: 1px solid #00000000;
 }
 
-.c0 svg {
+.c0 span {
   margin-right: 0rem;
 }
 
-.c0 svg path {
+.c0 span svg path {
   fill: #ffffff;
 }
 
@@ -513,11 +513,11 @@ exports[`Button renders with inset correctly 2`] = `
   border: 1px solid #00000000;
 }
 
-.c0 svg {
+.c0 span {
   margin-right: 0rem;
 }
 
-.c0 svg path {
+.c0 span svg path {
   fill: #ffffff;
 }
 
@@ -599,11 +599,11 @@ exports[`Button renders with inset correctly 3`] = `
   border: 1px solid #00000000;
 }
 
-.c0 svg {
+.c0 span {
   margin-right: 0rem;
 }
 
-.c0 svg path {
+.c0 span svg path {
   fill: #ffffff;
 }
 
@@ -692,11 +692,11 @@ exports[`Button renders with text and an icon correctly 1`] = `
   border: 1px solid #00000000;
 }
 
-.c0 svg {
+.c0 span {
   margin-right: 0.2rem;
 }
 
-.c0 svg path {
+.c0 span svg path {
   fill: #ffffff;
 }
 
@@ -784,11 +784,11 @@ exports[`Button renders with text and an icon correctly 2`] = `
   border: 1px solid #00000000;
 }
 
-.c0 svg {
+.c0 span {
   margin-right: 0.4rem;
 }
 
-.c0 svg path {
+.c0 span svg path {
   fill: #ffffff;
 }
 
@@ -876,11 +876,11 @@ exports[`Button renders with text and an icon correctly 3`] = `
   border: 1px solid #00000000;
 }
 
-.c0 svg {
+.c0 span {
   margin-right: 0.4rem;
 }
 
-.c0 svg path {
+.c0 span svg path {
   fill: #ffffff;
 }
 
@@ -968,11 +968,11 @@ exports[`Button renders with text, icon and inset correctly 1`] = `
   border: 1px solid #00000000;
 }
 
-.c0 svg {
+.c0 span {
   margin-right: 0.2rem;
 }
 
-.c0 svg path {
+.c0 span svg path {
   fill: #ffffff;
 }
 
@@ -1079,11 +1079,11 @@ exports[`Button renders with text, icon and inset correctly 2`] = `
   border: 1px solid #00000000;
 }
 
-.c0 svg {
+.c0 span {
   margin-right: 0.4rem;
 }
 
-.c0 svg path {
+.c0 span svg path {
   fill: #ffffff;
 }
 
@@ -1190,11 +1190,11 @@ exports[`Button renders with text, icon and inset correctly 3`] = `
   border: 1px solid #00000000;
 }
 
-.c0 svg {
+.c0 span {
   margin-right: 0.4rem;
 }
 
-.c0 svg path {
+.c0 span svg path {
   fill: #ffffff;
 }
 
@@ -1294,11 +1294,11 @@ exports[`Button with size large renders a bare variant correctly 1`] = `
   border: 1px solid #00000000;
 }
 
-.c0 svg {
+.c0 span {
   margin-right: 0rem;
 }
 
-.c0 svg path {
+.c0 span svg path {
   fill: #002966;
 }
 
@@ -1361,11 +1361,11 @@ exports[`Button with size large renders a ghost variant correctly 1`] = `
   border: 1px solid #002966;
 }
 
-.c0 svg {
+.c0 span {
   margin-right: 0rem;
 }
 
-.c0 svg path {
+.c0 span svg path {
   fill: #002966;
 }
 
@@ -1428,11 +1428,11 @@ exports[`Button with size large renders a primary variant with a label correctly
   border: 1px solid #00000000;
 }
 
-.c0 svg {
+.c0 span {
   margin-right: 0rem;
 }
 
-.c0 svg path {
+.c0 span svg path {
   fill: #ffffff;
 }
 
@@ -1502,11 +1502,11 @@ exports[`Button with size large renders with a bare icon correctly 1`] = `
   border: 1px solid #00000000;
 }
 
-.c0 svg {
+.c0 span {
   margin-right: 0.4rem;
 }
 
-.c0 svg path {
+.c0 span svg path {
   fill: #002966;
 }
 
@@ -1594,11 +1594,11 @@ exports[`Button with size large renders with an icon correctly 1`] = `
   border: 1px solid #00000000;
 }
 
-.c0 svg {
+.c0 span {
   margin-right: 0.4rem;
 }
 
-.c0 svg path {
+.c0 span svg path {
   fill: #ffffff;
 }
 
@@ -1679,11 +1679,11 @@ exports[`Button with size medium renders a bare variant correctly 1`] = `
   border: 1px solid #00000000;
 }
 
-.c0 svg {
+.c0 span {
   margin-right: 0rem;
 }
 
-.c0 svg path {
+.c0 span svg path {
   fill: #002966;
 }
 
@@ -1746,11 +1746,11 @@ exports[`Button with size medium renders a ghost variant correctly 1`] = `
   border: 1px solid #002966;
 }
 
-.c0 svg {
+.c0 span {
   margin-right: 0rem;
 }
 
-.c0 svg path {
+.c0 span svg path {
   fill: #002966;
 }
 
@@ -1813,11 +1813,11 @@ exports[`Button with size medium renders a primary variant with a label correctl
   border: 1px solid #00000000;
 }
 
-.c0 svg {
+.c0 span {
   margin-right: 0rem;
 }
 
-.c0 svg path {
+.c0 span svg path {
   fill: #ffffff;
 }
 
@@ -1887,11 +1887,11 @@ exports[`Button with size medium renders with a bare icon correctly 1`] = `
   border: 1px solid #00000000;
 }
 
-.c0 svg {
+.c0 span {
   margin-right: 0.4rem;
 }
 
-.c0 svg path {
+.c0 span svg path {
   fill: #002966;
 }
 
@@ -1979,11 +1979,11 @@ exports[`Button with size medium renders with an icon correctly 1`] = `
   border: 1px solid #00000000;
 }
 
-.c0 svg {
+.c0 span {
   margin-right: 0.4rem;
 }
 
-.c0 svg path {
+.c0 span svg path {
   fill: #ffffff;
 }
 
@@ -2064,11 +2064,11 @@ exports[`Button with size small renders a bare variant correctly 1`] = `
   border: 1px solid #00000000;
 }
 
-.c0 svg {
+.c0 span {
   margin-right: 0rem;
 }
 
-.c0 svg path {
+.c0 span svg path {
   fill: #002966;
 }
 
@@ -2131,11 +2131,11 @@ exports[`Button with size small renders a ghost variant correctly 1`] = `
   border: 1px solid #002966;
 }
 
-.c0 svg {
+.c0 span {
   margin-right: 0rem;
 }
 
-.c0 svg path {
+.c0 span svg path {
   fill: #002966;
 }
 
@@ -2198,11 +2198,11 @@ exports[`Button with size small renders a primary variant with a label correctly
   border: 1px solid #00000000;
 }
 
-.c0 svg {
+.c0 span {
   margin-right: 0rem;
 }
 
-.c0 svg path {
+.c0 span svg path {
   fill: #ffffff;
 }
 
@@ -2272,11 +2272,11 @@ exports[`Button with size small renders with a bare icon correctly 1`] = `
   border: 1px solid #00000000;
 }
 
-.c0 svg {
+.c0 span {
   margin-right: 0.2rem;
 }
 
-.c0 svg path {
+.c0 span svg path {
   fill: #002966;
 }
 
@@ -2364,11 +2364,11 @@ exports[`Button with size small renders with an icon correctly 1`] = `
   border: 1px solid #00000000;
 }
 
-.c0 svg {
+.c0 span {
   margin-right: 0.2rem;
 }
 
-.c0 svg path {
+.c0 span svg path {
   fill: #ffffff;
 }
 

--- a/components/Button/styledComponents/ButtonBase.tsx
+++ b/components/Button/styledComponents/ButtonBase.tsx
@@ -1,8 +1,5 @@
-import React from "react"
 import styled from "styled-components"
-import * as theme from "../../styles/variables"
-
-const { shades } = theme
+import { HTMLProps } from "react"
 
 type ButtonState = "default" | "hover" | "active" | "focus" | "disabled"
 
@@ -13,86 +10,44 @@ interface ParsedColorTheme {
   insetFont?: any
 }
 
-interface ButtonBaseProps {
-  label?: string
-  type: "primary" | "secondary"
-  colorTheme: ParsedColorTheme
-  ghost: boolean
-  size: "small" | "medium" | "large"
-  disabled?: boolean
-  bare: boolean
-  icon?: string
-  insetLabel?: string
-  onClick?: (event) => void
-  fontSize: number
-  lineHeight: number
+interface IStyledBaseButton {
+  customProps: {
+    label?: string
+    kind: "primary" | "secondary"
+    colorTheme: ParsedColorTheme
+    ghost: boolean
+    size: "small" | "medium" | "large"
+    disabled?: boolean
+    bare: boolean
+    icon?: string
+    insetLabel?: string
+    onClick?: (event) => void
+    fontSize: number
+    lineHeight: number
+  }
+  theme: any
+  [propName: string]: any
 }
 
-const ButtonBase: React.FC<ButtonBaseProps> = ({
-  label,
-  type,
-  ghost,
-  size,
-  disabled,
-  onClick,
-  icon,
-  bare,
-  colorTheme,
-  fontSize,
-  lineHeight,
-  children,
-}) => {
-  const iconOnly = icon && !label
-  // Ghost buttons have their font and background colors interchanged
-  const baseFontColor = ghost ? colorTheme.background : colorTheme.font
-  const baseBackgroundColor = ghost ? colorTheme.font : colorTheme.background
-  const lightenedBackgroundColor = baseBackgroundColor.set("hsl.l", "+0.1")
-  const lightenedFontColor = baseFontColor.set("hsl.l", "+0.3") // Used for ghost
-  const highlightColor = shades.lightBlue
+// Paddings
 
-  const getFontColor = (state: ButtonState) => {
-    switch (state) {
-      case "default":
-        if (bare) {
-          return baseBackgroundColor
-        }
-        return baseFontColor
-      case "hover":
-        if (bare) {
-          return lightenedBackgroundColor
-        }
-        if (ghost) {
-          return lightenedFontColor
-        }
-        return baseFontColor
-      default:
-        return baseFontColor
-    }
-  }
+const ICON_PADDINGS = {
+  small: 0.3,
+  medium: 0.5,
+  large: 0.7,
+}
 
-  const getBackgroundColor = (state: ButtonState) => {
-    if (bare) {
-      return state === "default" ? shades.transparent : shades.gray95
-    }
-    if (ghost) {
-      return shades.white
-    }
-    return state === "default" ? baseBackgroundColor : lightenedBackgroundColor
-  }
+const VERTICAL_PADINGS = {
+  small: 0.1,
+  medium: 0.4,
+  large: 0.6,
+}
 
-  const iconPaddings = {
-    small: 0.3,
-    medium: 0.5,
-    large: 0.7,
-  }
-
-  const verticalPaddings = {
-    small: 0.1,
-    medium: 0.4,
-    large: 0.6,
-  }
-
-  const horizontalPaddings = {
+const getHorizontalPadding = (props: IStyledBaseButton) => {
+  const {
+    customProps: { size, kind, fontSize },
+  } = props
+  const paddings = {
     small: {
       primary: fontSize / 2,
       secondary: fontSize / 2,
@@ -106,107 +61,192 @@ const ButtonBase: React.FC<ButtonBaseProps> = ({
       secondary: fontSize / 2,
     },
   }
-
-  const getVerticalPadding = () => {
-    return iconOnly ? iconPaddings[size!] : verticalPaddings[size!]
-  }
-
-  const getRightPadding = () => {
-    if (iconOnly) {
-      return iconPaddings[size!]
-    }
-    return horizontalPaddings[size!][type!]
-  }
-
-  const getLeftPadding = () => {
-    if (icon) {
-      return iconPaddings[size!]
-    }
-    return horizontalPaddings[size!][type!]
-  }
-
-  const getBorder = (state: ButtonState) => {
-    let borderColor
-    switch (state) {
-      case "active":
-      case "focus":
-        borderColor = ghost ? baseFontColor : highlightColor
-        break
-      case "hover":
-        borderColor = ghost ? lightenedFontColor : shades.transparent
-        break
-      default:
-        borderColor = ghost ? baseFontColor : shades.transparent
-        break
-    }
-    return `1px solid ${borderColor}`
-  }
-
-  const getIconColor = (state: ButtonState) => {
-    if (!bare) {
-      return baseFontColor
-    }
-    switch (state) {
-      case "focus":
-      case "active":
-        return lightenedBackgroundColor
-      case "default":
-      default:
-        return baseBackgroundColor
-    }
-  }
-
-  const getIconMargin = () => {
-    return icon && label ? (size === "small" ? "0.2rem" : "0.4rem") : "0rem"
-  }
-
-  const StyledButton = styled.button`
-    display: flex;
-    align-items: center;
-    font-size: ${`${fontSize}rem`};
-    line-height: ${`${lineHeight}rem`};
-    padding-left: ${`${getLeftPadding()}rem`};
-    padding-right: ${`${getRightPadding()}rem`};
-    color: ${getFontColor("default")};
-    background-color: ${getBackgroundColor("default")};
-    padding-top: ${`${getVerticalPadding()}rem`};
-    padding-bottom: ${`${getVerticalPadding()}rem`};
-    border-radius: 0.4rem;
-    border-style: none;
-    box-sizing: border-box;
-    border: ${getBorder("default")};
-    svg {
-      margin-right: ${getIconMargin()};
-      path {
-        fill: ${getIconColor("default")};
-      }
-    }
-    :hover,
-    :active,
-    :focus {
-      background-color: ${getBackgroundColor("hover")};
-    }
-    :active,
-    :focus {
-      border: ${getBorder("active")};
-      svg path {
-        fill: ${getIconColor("focus")};
-      }
-    }
-    :hover {
-      border: ${getBorder("hover")};
-      color: ${getFontColor("hover")};
-    }
-    :disabled {
-      opacity: 0.5;
-      cursor: not-allowed;
-    }
-  `
-  return (
-    <StyledButton onClick={onClick} disabled={disabled}>
-      {children}
-    </StyledButton>
-  )
+  return paddings[size][kind]
 }
 
-export default ButtonBase
+const getRightPadding = (props: IStyledBaseButton) => {
+  const {
+    customProps: { icon, label, size },
+  } = props
+  if (icon && !label) {
+    return ICON_PADDINGS[size!]
+  }
+  return getHorizontalPadding(props)
+}
+
+const getLeftPadding = (props: IStyledBaseButton) => {
+  const {
+    customProps: { icon, size },
+  } = props
+  if (icon) {
+    return ICON_PADDINGS[size!]
+  }
+  return getHorizontalPadding(props)
+}
+
+const getVerticalPadding = (props: IStyledBaseButton) => {
+  const {
+    customProps: { icon, label, size },
+  } = props
+  const iconOnly = icon && !label
+  return iconOnly ? ICON_PADDINGS[size!] : VERTICAL_PADINGS[size!]
+}
+
+// Colors
+
+const getHighlighColor = (props: IStyledBaseButton) =>
+  props.theme.shades.lightBlue
+
+const getBaseBackgroundColor = (props: IStyledBaseButton) => {
+  const {
+    customProps: { ghost, colorTheme },
+  } = props
+  return ghost ? colorTheme.font : colorTheme.background
+}
+
+const getBaseFontColor = (props: IStyledBaseButton) => {
+  const {
+    customProps: { ghost, colorTheme },
+  } = props
+  return ghost ? colorTheme.background : colorTheme.font
+}
+
+const getLightenedBackgroundColor = (props: IStyledBaseButton) => {
+  return getBaseBackgroundColor(props).set("hsl.l", "+0.1")
+}
+
+const getLightenedFontColor = (props: IStyledBaseButton) => {
+  return getBaseFontColor(props).set("hsl.l", "+0.3") // Used for ghost
+}
+
+const getFontColor = (state: ButtonState, props: IStyledBaseButton) => {
+  const {
+    customProps: { bare, ghost },
+  } = props
+  const baseFontColor = getBaseFontColor(props)
+  switch (state) {
+    case "default":
+      if (bare) {
+        return getBaseBackgroundColor(props)
+      }
+      return baseFontColor
+    case "hover":
+      if (bare) {
+        return getLightenedBackgroundColor(props)
+      }
+      if (ghost) {
+        return getLightenedFontColor(props)
+      }
+      return baseFontColor
+    default:
+      return baseFontColor
+  }
+}
+
+const getBackgroundColor = (state: ButtonState, props: IStyledBaseButton) => {
+  const {
+    customProps: { bare, ghost },
+    theme,
+  } = props
+  if (bare) {
+    return state === "default" ? theme.shades.transparent : theme.shades.gray95
+  }
+  if (ghost) {
+    return theme.shades.white
+  }
+  return state === "default"
+    ? getBaseBackgroundColor(props)
+    : getLightenedBackgroundColor(props)
+}
+
+const getIconColor = (state: ButtonState, props: IStyledBaseButton) => {
+  const {
+    customProps: { bare },
+  } = props
+  if (!bare) {
+    return getBaseFontColor(props)
+  }
+  switch (state) {
+    case "focus":
+    case "active":
+      return getLightenedBackgroundColor(props)
+    case "default":
+    default:
+      return getBaseBackgroundColor(props)
+  }
+}
+
+const getBorder = (state: ButtonState, props: IStyledBaseButton) => {
+  const {
+    customProps: { ghost },
+    theme,
+  } = props
+  let borderColor
+  switch (state) {
+    case "active":
+    case "focus":
+      borderColor = ghost ? getBaseFontColor(props) : getHighlighColor(props)
+      break
+    case "hover":
+      borderColor = ghost
+        ? getLightenedFontColor(props)
+        : theme.shades.transparent
+      break
+    default:
+      borderColor = ghost ? getBaseFontColor(props) : theme.shades.transparent
+      break
+  }
+  return `1px solid ${borderColor}`
+}
+
+const getIconMargin = (props: IStyledBaseButton) => {
+  const {
+    customProps: { icon, label, size },
+  } = props
+  return icon && label ? (size === "small" ? "0.2rem" : "0.4rem") : "0rem"
+}
+
+const StyledButton = styled.button<IStyledBaseButton>`
+  display: flex;
+  align-items: center;
+  font-size: ${({ customProps: { fontSize } }) => `${fontSize}rem`};
+  line-height: ${({ customProps: { lineHeight } }) => `${lineHeight}rem`};
+  padding-left: ${props => `${getLeftPadding(props)}rem`};
+  padding-right: ${props => `${getRightPadding(props)}rem`};
+  color: ${props => getFontColor("default", props)};
+  background-color: ${props => getBackgroundColor("default", props)};
+  padding-top: ${props => `${getVerticalPadding(props)}rem`};
+  padding-bottom: ${props => `${getVerticalPadding(props)}rem`};
+  border-radius: 0.4rem;
+  border-style: none;
+  box-sizing: border-box;
+  border: ${props => getBorder("default", props)};
+  span {
+    margin-right: ${props => getIconMargin(props)};
+    svg path {
+      fill: ${props => getIconColor("default", props)};
+    }
+  }
+  :hover,
+  :active,
+  :focus {
+    background-color: ${props => getBackgroundColor("hover", props)};
+  }
+  :active,
+  :focus {
+    border: ${props => getBorder("active", props)};
+    svg path {
+      fill: ${props => getIconColor("focus", props)};
+    }
+  }
+  :hover {
+    border: ${props => getBorder("hover", props)};
+    color: ${props => getFontColor("hover", props)};
+  }
+  :disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+`
+
+export default StyledButton

--- a/components/Button/styledComponents/ButtonBase.tsx
+++ b/components/Button/styledComponents/ButtonBase.tsx
@@ -1,5 +1,5 @@
 import styled from "styled-components"
-import { HTMLProps } from "react"
+import { IStyled } from "../../common/types"
 
 type ButtonState = "default" | "hover" | "active" | "focus" | "disabled"
 
@@ -10,25 +10,22 @@ interface ParsedColorTheme {
   insetFont?: any
 }
 
-interface IStyledBaseButton {
-  customProps: {
-    label?: string
-    kind: "primary" | "secondary"
-    colorTheme: ParsedColorTheme
-    ghost: boolean
-    size: "small" | "medium" | "large"
-    disabled?: boolean
-    bare: boolean
-    icon?: string
-    insetLabel?: string
-    onClick?: (event) => void
-    fontSize: number
-    lineHeight: number
-  }
-  theme: any
-  [propName: string]: any
+interface BaseButtonProps {
+  label?: string
+  kind: "primary" | "secondary"
+  colorTheme: ParsedColorTheme
+  ghost: boolean
+  size: "small" | "medium" | "large"
+  disabled?: boolean
+  bare: boolean
+  icon?: string
+  insetLabel?: string
+  onClick?: (event) => void
+  fontSize: number
+  lineHeight: number
 }
 
+type IStyledBaseButton = IStyled<BaseButtonProps>
 // Paddings
 
 const ICON_PADDINGS = {

--- a/components/Button/styledComponents/ButtonBase.tsx
+++ b/components/Button/styledComponents/ButtonBase.tsx
@@ -12,7 +12,7 @@ interface ParsedColorTheme {
 
 interface BaseButtonProps {
   label?: string
-  kind: "primary" | "secondary"
+  type: "primary" | "secondary"
   colorTheme: ParsedColorTheme
   ghost: boolean
   size: "small" | "medium" | "large"
@@ -42,7 +42,7 @@ const VERTICAL_PADINGS = {
 
 const getHorizontalPadding = (props: IStyledBaseButton) => {
   const {
-    customProps: { size, kind, fontSize },
+    customProps: { size, type, fontSize },
   } = props
   const paddings = {
     small: {
@@ -58,7 +58,7 @@ const getHorizontalPadding = (props: IStyledBaseButton) => {
       secondary: fontSize / 2,
     },
   }
-  return paddings[size][kind]
+  return paddings[size][type]
 }
 
 const getRightPadding = (props: IStyledBaseButton) => {

--- a/components/Button/styledComponents/ButtonInset.tsx
+++ b/components/Button/styledComponents/ButtonInset.tsx
@@ -1,32 +1,24 @@
-import React from "react"
 import styled from "styled-components"
 
 interface ButtonInsetProps {
-  label: string
-  backgroundColor: string
-  fontColor: string
-  fontSize: string
-  lineHeight: string
+  customProps: {
+    backgroundColor: string
+    fontColor: string
+    fontSize: string
+    lineHeight: string
+  }
+  theme: any
 }
 
-const ButtonInset: React.FC<ButtonInsetProps> = ({
-  label,
-  backgroundColor,
-  fontColor,
-  fontSize,
-  lineHeight,
-}) => {
-  const StyledDiv = styled.div`
-    display: inline-flex;
-    background-color: ${backgroundColor};
-    color: ${fontColor};
-    font-size: ${fontSize};
-    line-height: ${lineHeight};
-    border-radius: 0.4rem;
-    margin-left: 0.4rem;
-    padding: 0rem 0.3rem 0rem 0.3rem;
-  `
-  return <>{label ? <StyledDiv>{label}</StyledDiv> : null}</>
-}
+const ButtonInset = styled.div<ButtonInsetProps>`
+  display: inline-flex;
+  background-color: ${({ customProps }) => customProps.backgroundColor};
+  color: ${({ customProps }) => customProps.fontColor};
+  font-size: ${({ customProps }) => customProps.fontSize};
+  line-height: ${({ customProps }) => customProps.lineHeight};
+  border-radius: 0.4rem;
+  margin-left: 0.4rem;
+  padding: 0rem 0.3rem 0rem 0.3rem;
+`
 
 export default ButtonInset

--- a/components/Button/styledComponents/ButtonInset.tsx
+++ b/components/Button/styledComponents/ButtonInset.tsx
@@ -1,16 +1,14 @@
 import styled from "styled-components"
+import { IStyled } from "../../common/types"
 
 interface ButtonInsetProps {
-  customProps: {
-    backgroundColor: string
-    fontColor: string
-    fontSize: string
-    lineHeight: string
-  }
-  theme: any
+  backgroundColor: string
+  fontColor: string
+  fontSize: string
+  lineHeight: string
 }
 
-const ButtonInset = styled.div<ButtonInsetProps>`
+const ButtonInset = styled.div<IStyled<ButtonInsetProps>>`
   display: inline-flex;
   background-color: ${({ customProps }) => customProps.backgroundColor};
   color: ${({ customProps }) => customProps.fontColor};

--- a/components/Modal/ModalWrapper.tsx
+++ b/components/Modal/ModalWrapper.tsx
@@ -7,7 +7,6 @@ import {
   RightPanelModal,
   BottomPanelModal,
 } from "./variants/index"
-import * as theme from "../styles/variables"
 import Icon from "../Icon"
 import Dialog from "rc-dialog"
 import "rc-dialog/assets/index.css"
@@ -43,23 +42,102 @@ export interface ModalWrapperProps {
   destroyOnClose?: boolean
 }
 
+interface IStyledDialog {
+  customProps: ModalWrapperProps
+  theme: any
+  [propName: string]: any
+}
+
+// Animation related
+const appearDuration = 250
+const transitionName = `modal`
+const maskTransitionName = `modalMask`
+const maskDuration = 100
+const modalEnterTransitionPath = `cubic-bezier(0, 0, 0, 1)`
+const modalLeaveTransitionPath = `cubic-bezier(1, 0, 1, 1)`
+const animationDelay = `50ms`
+
+// Animations on leave are not working for rc-dialog, this happens only when
+// styiling the Dialog using styled components. It is probably the case that
+// the Dialog component is being re-created on close, causing the previous
+// stored ref to be lost
+const StyledDialog = styled(Dialog)<IStyledDialog>`
+  .rc-dialog-body {
+    padding: 0;
+    height: calc(100vh - 14rem);
+    min-height: 35rem;
+  }
+  .rc-dialog-content {
+    border-radius: ${borderRadius};
+  }
+  width: ${({ customProps: { size } }) => sizeToWidth[size!]} !important;
+  .rc-dialog-close {
+    right: -1rem;
+    top: -1rem;
+    opacity: unset;
+    padding: 0.15rem;
+    line-height: 0;
+    background-color: ${({ theme }) => theme.shades.gray50};
+    border-radius: 999px;
+    svg {
+        fill: ${({ theme }) => theme.shades.gray90};
+      }
+    }
+  }
+  &.${transitionName}-appear {
+    opacity: 0;
+    transform: scale(0.9);
+  }
+
+  &.${transitionName}-appear.${transitionName}-appear-active {
+    opacity: 1;
+    transform: scale(1.0);
+    transition: opacity ${appearDuration}ms ${modalEnterTransitionPath} ${animationDelay}, transform ${appearDuration}ms ${modalEnterTransitionPath} ${animationDelay};
+  }
+
+  &.${transitionName}-leave {
+    opacity: 1;
+    transform: scale(1);
+  }
+
+  &.${transitionName}-leave.${transitionName}-leave-active {
+    opacity: 0;
+    transform: scale(0.9);
+    transition: opacity ${appearDuration}ms ${modalLeaveTransitionPath}, transform ${appearDuration}ms ${modalLeaveTransitionPath};
+  }
+
+  &.${maskTransitionName}-appear {
+    opacity: 0;
+  }
+
+  &.${maskTransitionName}-appear.${maskTransitionName}-appear-active {
+    opacity: 1;
+    transition: opacity ${maskDuration}ms ease-out;
+  }
+
+  &.${maskTransitionName}-leave {
+    opacity: 1;
+  }
+
+  &.${maskTransitionName}-leave.${maskTransitionName}-leave-active {
+    opacity: 0;
+    transition: opacity ${maskDuration}ms ease-out;
+  }
+`
+
 /**
  * The external interface for the modal
  */
 const ModalWrapper: React.FC<ModalWrapperProps> = ({
-  size = "medium",
+  size,
   header,
   body,
   footer,
-  padding = {
-    vertical: "2.1rem",
-    horizontal: "2.8rem",
-  },
   getContainer,
-  visible = false,
+  visible,
   onClose,
   panel,
-  destroyOnClose = false,
+  destroyOnClose,
 }) => {
   /**
    * Renders the appopriate variant based on the availability of a
@@ -93,85 +171,11 @@ const ModalWrapper: React.FC<ModalWrapperProps> = ({
     }
   }
 
-  // Animation related
-  const appearDuration = 250
-  const transitionName = `modal`
-  const maskTransitionName = `modalMask`
-  const maskDuration = 100
-  const modalEnterTransitionPath = `cubic-bezier(0, 0, 0, 1)`
-  const modalLeaveTransitionPath = `cubic-bezier(1, 0, 1, 1)`
-  const animationDelay = `50ms`
-
-  // Animations on leave are not working for rc-dialog, this happens only when
-  // styiling the Dialog using styled components. It is probably the case that
-  // the Dialog component is being re-created on close, causing the previous
-  // stored ref to be lost
-  const StyledDialog = styled(Dialog)`
-    .rc-dialog-body {
-      padding: 0;
-      height: calc(100vh - 14rem);
-      min-height: 35rem;
-    }
-    .rc-dialog-content {
-      border-radius: ${borderRadius};
-    }
-    width: ${sizeToWidth[size!]} !important;
-    .rc-dialog-close {
-      right: -1rem;
-      top: -1rem;
-      opacity: unset;
-      padding: 0.15rem;
-      line-height: 0;
-      background-color: ${theme.shades.gray50};
-      border-radius: 999px;
-      svg {
-          fill: ${theme.shades.gray90};
-        }
-      }
-    }
-    &.${transitionName}-appear {
-      opacity: 0;
-      transform: scale(0.9);
-    }
-
-    &.${transitionName}-appear.${transitionName}-appear-active {
-      opacity: 1;
-      transform: scale(1.0);
-      transition: opacity ${appearDuration}ms ${modalEnterTransitionPath} ${animationDelay}, transform ${appearDuration}ms ${modalEnterTransitionPath} ${animationDelay};
-    }
-
-    &.${transitionName}-leave {
-      opacity: 1;
-      transform: scale(1);
-    }
-
-    &.${transitionName}-leave.${transitionName}-leave-active {
-      opacity: 0;
-      transform: scale(0.9);
-      transition: opacity ${appearDuration}ms ${modalLeaveTransitionPath}, transform ${appearDuration}ms ${modalLeaveTransitionPath};
-    }
-
-    &.${maskTransitionName}-appear {
-      opacity: 0;
-    }
-
-    &.${maskTransitionName}-appear.${maskTransitionName}-appear-active {
-      opacity: 1;
-      transition: opacity ${maskDuration}ms ease-out;
-    }
-
-    &.${maskTransitionName}-leave {
-      opacity: 1;
-    }
-
-    &.${maskTransitionName}-leave.${maskTransitionName}-leave-active {
-      opacity: 0;
-      transition: opacity ${maskDuration}ms ease-out;
-    }
-  `
-
   return (
     <StyledDialog
+      customProps={{
+        size,
+      }}
       getContainer={getContainer}
       visible={visible}
       onClose={onClose}
@@ -181,11 +185,25 @@ const ModalWrapper: React.FC<ModalWrapperProps> = ({
       maskTransitionName={maskTransitionName}>
       <ModalProxy
         header={<Header {...header} />}
-        body={<Main setBodyRef={setBodyRef}>{body}</Main>}
-        footer={<Footer showBorder={showFooterBorder}>{footer}</Footer>}
+        body={<Main ref={setBodyRef}>{body}</Main>}
+        footer={
+          <Footer customProps={{ showBorder: showFooterBorder }}>
+            {footer}
+          </Footer>
+        }
       />
     </StyledDialog>
   )
+}
+
+ModalWrapper.defaultProps = {
+  size: "medium",
+  padding: {
+    vertical: "2.1rem",
+    horizontal: "2.8rem",
+  },
+  visible: false,
+  destroyOnClose: false,
 }
 
 export default ModalWrapper

--- a/components/Modal/__tests__/__snapshots__/Modal.test.tsx.snap
+++ b/components/Modal/__tests__/__snapshots__/Modal.test.tsx.snap
@@ -1,6 +1,55 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Modal with size large with a bottom panel 1`] = `
+.c6 {
+  padding: 2.1rem 2.8rem 0rem;
+  overflow-y: auto;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+}
+
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  padding: 2.1rem 2.8rem;
+  border-radius: 0.4rem 0.4rem 0rem 0rem;
+  background: #f2f2f2;
+}
+
+.c4 {
+  font-size: 20px;
+  line-height: 30px;
+  color: #333333;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c7 {
+  padding: 2.1rem 2.8rem;
+  justify-self: flex-end;
+  border-top: none;
+}
+
 .c2 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -107,55 +156,6 @@ exports[`Modal with size large with a bottom panel 1`] = `
   transition: opacity 100ms ease-out;
 }
 
-.c3 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  padding: 2.1rem 2.8rem;
-  border-radius: 0.4rem 0.4rem 0rem 0rem;
-  background: #f2f2f2;
-}
-
-.c4 {
-  font-size: 20px;
-  line-height: 30px;
-  color: #333333;
-}
-
-.c5 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  -webkit-box-pack: end;
-  -webkit-justify-content: flex-end;
-  -ms-flex-pack: end;
-  justify-content: flex-end;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.c6 {
-  padding: 2.1rem 2.8rem 0rem;
-  overflow-y: auto;
-  -webkit-flex: 1 1 auto;
-  -ms-flex: 1 1 auto;
-  flex: 1 1 auto;
-}
-
-.c7 {
-  padding: 2.1rem 2.8rem;
-  justify-self: flex-end;
-  border-top: none;
-}
-
 <div
   class="rc-dialog-wrap "
   role="dialog"
@@ -248,6 +248,55 @@ exports[`Modal with size large with a bottom panel 1`] = `
 `;
 
 exports[`Modal with size large with a left panel 1`] = `
+.c9 {
+  padding: 2.1rem 2.8rem 0rem;
+  overflow-y: auto;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+}
+
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  padding: 2.1rem 2.8rem;
+  border-radius: 0.4rem 0.4rem 0rem 0rem;
+  background: #f2f2f2;
+}
+
+.c4 {
+  font-size: 20px;
+  line-height: 30px;
+  color: #333333;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c10 {
+  padding: 2.1rem 2.8rem;
+  justify-self: flex-end;
+  border-top: none;
+}
+
 .c2 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -379,55 +428,6 @@ exports[`Modal with size large with a left panel 1`] = `
   opacity: 0;
   -webkit-transition: opacity 100ms ease-out;
   transition: opacity 100ms ease-out;
-}
-
-.c3 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  padding: 2.1rem 2.8rem;
-  border-radius: 0.4rem 0.4rem 0rem 0rem;
-  background: #f2f2f2;
-}
-
-.c4 {
-  font-size: 20px;
-  line-height: 30px;
-  color: #333333;
-}
-
-.c5 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  -webkit-box-pack: end;
-  -webkit-justify-content: flex-end;
-  -ms-flex-pack: end;
-  justify-content: flex-end;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.c9 {
-  padding: 2.1rem 2.8rem 0rem;
-  overflow-y: auto;
-  -webkit-flex: 1 1 auto;
-  -ms-flex: 1 1 auto;
-  flex: 1 1 auto;
-}
-
-.c10 {
-  padding: 2.1rem 2.8rem;
-  justify-self: flex-end;
-  border-top: none;
 }
 
 <div
@@ -530,6 +530,55 @@ exports[`Modal with size large with a left panel 1`] = `
 `;
 
 exports[`Modal with size large with a right panel 1`] = `
+.c8 {
+  padding: 2.1rem 2.8rem 0rem;
+  overflow-y: auto;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+}
+
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  padding: 2.1rem 2.8rem;
+  border-radius: 0.4rem 0.4rem 0rem 0rem;
+  background: #f2f2f2;
+}
+
+.c4 {
+  font-size: 20px;
+  line-height: 30px;
+  color: #333333;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c9 {
+  padding: 2.1rem 2.8rem;
+  justify-self: flex-end;
+  border-top: none;
+}
+
 .c2 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -664,55 +713,6 @@ exports[`Modal with size large with a right panel 1`] = `
   opacity: 0;
   -webkit-transition: opacity 100ms ease-out;
   transition: opacity 100ms ease-out;
-}
-
-.c3 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  padding: 2.1rem 2.8rem;
-  border-radius: 0.4rem 0.4rem 0rem 0rem;
-  background: #f2f2f2;
-}
-
-.c4 {
-  font-size: 20px;
-  line-height: 30px;
-  color: #333333;
-}
-
-.c5 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  -webkit-box-pack: end;
-  -webkit-justify-content: flex-end;
-  -ms-flex-pack: end;
-  justify-content: flex-end;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.c8 {
-  padding: 2.1rem 2.8rem 0rem;
-  overflow-y: auto;
-  -webkit-flex: 1 1 auto;
-  -ms-flex: 1 1 auto;
-  flex: 1 1 auto;
-}
-
-.c9 {
-  padding: 2.1rem 2.8rem;
-  justify-self: flex-end;
-  border-top: none;
 }
 
 <div
@@ -815,6 +815,55 @@ exports[`Modal with size large with a right panel 1`] = `
 `;
 
 exports[`Modal with size large with right section in header 1`] = `
+.c6 {
+  padding: 2.1rem 2.8rem 0rem;
+  overflow-y: auto;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+}
+
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  padding: 2.1rem 2.8rem;
+  border-radius: 0.4rem 0.4rem 0rem 0rem;
+  background: #f2f2f2;
+}
+
+.c4 {
+  font-size: 20px;
+  line-height: 30px;
+  color: #333333;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c7 {
+  padding: 2.1rem 2.8rem;
+  justify-self: flex-end;
+  border-top: none;
+}
+
 .c2 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -913,55 +962,6 @@ exports[`Modal with size large with right section in header 1`] = `
   opacity: 0;
   -webkit-transition: opacity 100ms ease-out;
   transition: opacity 100ms ease-out;
-}
-
-.c3 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  padding: 2.1rem 2.8rem;
-  border-radius: 0.4rem 0.4rem 0rem 0rem;
-  background: #f2f2f2;
-}
-
-.c4 {
-  font-size: 20px;
-  line-height: 30px;
-  color: #333333;
-}
-
-.c5 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  -webkit-box-pack: end;
-  -webkit-justify-content: flex-end;
-  -ms-flex-pack: end;
-  justify-content: flex-end;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.c6 {
-  padding: 2.1rem 2.8rem 0rem;
-  overflow-y: auto;
-  -webkit-flex: 1 1 auto;
-  -ms-flex: 1 1 auto;
-  flex: 1 1 auto;
-}
-
-.c7 {
-  padding: 2.1rem 2.8rem;
-  justify-self: flex-end;
-  border-top: none;
 }
 
 <div
@@ -1055,6 +1055,55 @@ exports[`Modal with size large with right section in header 1`] = `
 `;
 
 exports[`Modal with size large with simple config 1`] = `
+.c6 {
+  padding: 2.1rem 2.8rem 0rem;
+  overflow-y: auto;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+}
+
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  padding: 2.1rem 2.8rem;
+  border-radius: 0.4rem 0.4rem 0rem 0rem;
+  background: #f2f2f2;
+}
+
+.c4 {
+  font-size: 20px;
+  line-height: 30px;
+  color: #333333;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c7 {
+  padding: 2.1rem 2.8rem;
+  justify-self: flex-end;
+  border-top: none;
+}
+
 .c2 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -1155,55 +1204,6 @@ exports[`Modal with size large with simple config 1`] = `
   transition: opacity 100ms ease-out;
 }
 
-.c3 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  padding: 2.1rem 2.8rem;
-  border-radius: 0.4rem 0.4rem 0rem 0rem;
-  background: #f2f2f2;
-}
-
-.c4 {
-  font-size: 20px;
-  line-height: 30px;
-  color: #333333;
-}
-
-.c5 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  -webkit-box-pack: end;
-  -webkit-justify-content: flex-end;
-  -ms-flex-pack: end;
-  justify-content: flex-end;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.c6 {
-  padding: 2.1rem 2.8rem 0rem;
-  overflow-y: auto;
-  -webkit-flex: 1 1 auto;
-  -ms-flex: 1 1 auto;
-  flex: 1 1 auto;
-}
-
-.c7 {
-  padding: 2.1rem 2.8rem;
-  justify-self: flex-end;
-  border-top: none;
-}
-
 <div
   class="rc-dialog-wrap "
   role="dialog"
@@ -1289,6 +1289,55 @@ exports[`Modal with size large with simple config 1`] = `
 `;
 
 exports[`Modal with size medium with a bottom panel 1`] = `
+.c6 {
+  padding: 2.1rem 2.8rem 0rem;
+  overflow-y: auto;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+}
+
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  padding: 2.1rem 2.8rem;
+  border-radius: 0.4rem 0.4rem 0rem 0rem;
+  background: #f2f2f2;
+}
+
+.c4 {
+  font-size: 20px;
+  line-height: 30px;
+  color: #333333;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c7 {
+  padding: 2.1rem 2.8rem;
+  justify-self: flex-end;
+  border-top: none;
+}
+
 .c2 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -1395,55 +1444,6 @@ exports[`Modal with size medium with a bottom panel 1`] = `
   transition: opacity 100ms ease-out;
 }
 
-.c3 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  padding: 2.1rem 2.8rem;
-  border-radius: 0.4rem 0.4rem 0rem 0rem;
-  background: #f2f2f2;
-}
-
-.c4 {
-  font-size: 20px;
-  line-height: 30px;
-  color: #333333;
-}
-
-.c5 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  -webkit-box-pack: end;
-  -webkit-justify-content: flex-end;
-  -ms-flex-pack: end;
-  justify-content: flex-end;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.c6 {
-  padding: 2.1rem 2.8rem 0rem;
-  overflow-y: auto;
-  -webkit-flex: 1 1 auto;
-  -ms-flex: 1 1 auto;
-  flex: 1 1 auto;
-}
-
-.c7 {
-  padding: 2.1rem 2.8rem;
-  justify-self: flex-end;
-  border-top: none;
-}
-
 <div
   class="rc-dialog-wrap "
   role="dialog"
@@ -1536,6 +1536,55 @@ exports[`Modal with size medium with a bottom panel 1`] = `
 `;
 
 exports[`Modal with size medium with a left panel 1`] = `
+.c9 {
+  padding: 2.1rem 2.8rem 0rem;
+  overflow-y: auto;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+}
+
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  padding: 2.1rem 2.8rem;
+  border-radius: 0.4rem 0.4rem 0rem 0rem;
+  background: #f2f2f2;
+}
+
+.c4 {
+  font-size: 20px;
+  line-height: 30px;
+  color: #333333;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c10 {
+  padding: 2.1rem 2.8rem;
+  justify-self: flex-end;
+  border-top: none;
+}
+
 .c2 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -1667,55 +1716,6 @@ exports[`Modal with size medium with a left panel 1`] = `
   opacity: 0;
   -webkit-transition: opacity 100ms ease-out;
   transition: opacity 100ms ease-out;
-}
-
-.c3 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  padding: 2.1rem 2.8rem;
-  border-radius: 0.4rem 0.4rem 0rem 0rem;
-  background: #f2f2f2;
-}
-
-.c4 {
-  font-size: 20px;
-  line-height: 30px;
-  color: #333333;
-}
-
-.c5 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  -webkit-box-pack: end;
-  -webkit-justify-content: flex-end;
-  -ms-flex-pack: end;
-  justify-content: flex-end;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.c9 {
-  padding: 2.1rem 2.8rem 0rem;
-  overflow-y: auto;
-  -webkit-flex: 1 1 auto;
-  -ms-flex: 1 1 auto;
-  flex: 1 1 auto;
-}
-
-.c10 {
-  padding: 2.1rem 2.8rem;
-  justify-self: flex-end;
-  border-top: none;
 }
 
 <div
@@ -1818,6 +1818,55 @@ exports[`Modal with size medium with a left panel 1`] = `
 `;
 
 exports[`Modal with size medium with a right panel 1`] = `
+.c8 {
+  padding: 2.1rem 2.8rem 0rem;
+  overflow-y: auto;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+}
+
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  padding: 2.1rem 2.8rem;
+  border-radius: 0.4rem 0.4rem 0rem 0rem;
+  background: #f2f2f2;
+}
+
+.c4 {
+  font-size: 20px;
+  line-height: 30px;
+  color: #333333;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c9 {
+  padding: 2.1rem 2.8rem;
+  justify-self: flex-end;
+  border-top: none;
+}
+
 .c2 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -1952,55 +2001,6 @@ exports[`Modal with size medium with a right panel 1`] = `
   opacity: 0;
   -webkit-transition: opacity 100ms ease-out;
   transition: opacity 100ms ease-out;
-}
-
-.c3 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  padding: 2.1rem 2.8rem;
-  border-radius: 0.4rem 0.4rem 0rem 0rem;
-  background: #f2f2f2;
-}
-
-.c4 {
-  font-size: 20px;
-  line-height: 30px;
-  color: #333333;
-}
-
-.c5 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  -webkit-box-pack: end;
-  -webkit-justify-content: flex-end;
-  -ms-flex-pack: end;
-  justify-content: flex-end;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.c8 {
-  padding: 2.1rem 2.8rem 0rem;
-  overflow-y: auto;
-  -webkit-flex: 1 1 auto;
-  -ms-flex: 1 1 auto;
-  flex: 1 1 auto;
-}
-
-.c9 {
-  padding: 2.1rem 2.8rem;
-  justify-self: flex-end;
-  border-top: none;
 }
 
 <div
@@ -2103,6 +2103,55 @@ exports[`Modal with size medium with a right panel 1`] = `
 `;
 
 exports[`Modal with size medium with right section in header 1`] = `
+.c6 {
+  padding: 2.1rem 2.8rem 0rem;
+  overflow-y: auto;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+}
+
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  padding: 2.1rem 2.8rem;
+  border-radius: 0.4rem 0.4rem 0rem 0rem;
+  background: #f2f2f2;
+}
+
+.c4 {
+  font-size: 20px;
+  line-height: 30px;
+  color: #333333;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c7 {
+  padding: 2.1rem 2.8rem;
+  justify-self: flex-end;
+  border-top: none;
+}
+
 .c2 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -2201,55 +2250,6 @@ exports[`Modal with size medium with right section in header 1`] = `
   opacity: 0;
   -webkit-transition: opacity 100ms ease-out;
   transition: opacity 100ms ease-out;
-}
-
-.c3 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  padding: 2.1rem 2.8rem;
-  border-radius: 0.4rem 0.4rem 0rem 0rem;
-  background: #f2f2f2;
-}
-
-.c4 {
-  font-size: 20px;
-  line-height: 30px;
-  color: #333333;
-}
-
-.c5 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  -webkit-box-pack: end;
-  -webkit-justify-content: flex-end;
-  -ms-flex-pack: end;
-  justify-content: flex-end;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.c6 {
-  padding: 2.1rem 2.8rem 0rem;
-  overflow-y: auto;
-  -webkit-flex: 1 1 auto;
-  -ms-flex: 1 1 auto;
-  flex: 1 1 auto;
-}
-
-.c7 {
-  padding: 2.1rem 2.8rem;
-  justify-self: flex-end;
-  border-top: none;
 }
 
 <div
@@ -2343,6 +2343,55 @@ exports[`Modal with size medium with right section in header 1`] = `
 `;
 
 exports[`Modal with size medium with simple config 1`] = `
+.c6 {
+  padding: 2.1rem 2.8rem 0rem;
+  overflow-y: auto;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+}
+
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  padding: 2.1rem 2.8rem;
+  border-radius: 0.4rem 0.4rem 0rem 0rem;
+  background: #f2f2f2;
+}
+
+.c4 {
+  font-size: 20px;
+  line-height: 30px;
+  color: #333333;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c7 {
+  padding: 2.1rem 2.8rem;
+  justify-self: flex-end;
+  border-top: none;
+}
+
 .c2 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -2443,55 +2492,6 @@ exports[`Modal with size medium with simple config 1`] = `
   transition: opacity 100ms ease-out;
 }
 
-.c3 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  padding: 2.1rem 2.8rem;
-  border-radius: 0.4rem 0.4rem 0rem 0rem;
-  background: #f2f2f2;
-}
-
-.c4 {
-  font-size: 20px;
-  line-height: 30px;
-  color: #333333;
-}
-
-.c5 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  -webkit-box-pack: end;
-  -webkit-justify-content: flex-end;
-  -ms-flex-pack: end;
-  justify-content: flex-end;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.c6 {
-  padding: 2.1rem 2.8rem 0rem;
-  overflow-y: auto;
-  -webkit-flex: 1 1 auto;
-  -ms-flex: 1 1 auto;
-  flex: 1 1 auto;
-}
-
-.c7 {
-  padding: 2.1rem 2.8rem;
-  justify-self: flex-end;
-  border-top: none;
-}
-
 <div
   class="rc-dialog-wrap "
   role="dialog"
@@ -2577,6 +2577,55 @@ exports[`Modal with size medium with simple config 1`] = `
 `;
 
 exports[`Modal with size small with a bottom panel 1`] = `
+.c6 {
+  padding: 2.1rem 2.8rem 0rem;
+  overflow-y: auto;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+}
+
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  padding: 2.1rem 2.8rem;
+  border-radius: 0.4rem 0.4rem 0rem 0rem;
+  background: #f2f2f2;
+}
+
+.c4 {
+  font-size: 20px;
+  line-height: 30px;
+  color: #333333;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c7 {
+  padding: 2.1rem 2.8rem;
+  justify-self: flex-end;
+  border-top: none;
+}
+
 .c2 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -2683,55 +2732,6 @@ exports[`Modal with size small with a bottom panel 1`] = `
   transition: opacity 100ms ease-out;
 }
 
-.c3 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  padding: 2.1rem 2.8rem;
-  border-radius: 0.4rem 0.4rem 0rem 0rem;
-  background: #f2f2f2;
-}
-
-.c4 {
-  font-size: 20px;
-  line-height: 30px;
-  color: #333333;
-}
-
-.c5 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  -webkit-box-pack: end;
-  -webkit-justify-content: flex-end;
-  -ms-flex-pack: end;
-  justify-content: flex-end;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.c6 {
-  padding: 2.1rem 2.8rem 0rem;
-  overflow-y: auto;
-  -webkit-flex: 1 1 auto;
-  -ms-flex: 1 1 auto;
-  flex: 1 1 auto;
-}
-
-.c7 {
-  padding: 2.1rem 2.8rem;
-  justify-self: flex-end;
-  border-top: none;
-}
-
 <div
   class="rc-dialog-wrap "
   role="dialog"
@@ -2824,6 +2824,55 @@ exports[`Modal with size small with a bottom panel 1`] = `
 `;
 
 exports[`Modal with size small with a left panel 1`] = `
+.c9 {
+  padding: 2.1rem 2.8rem 0rem;
+  overflow-y: auto;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+}
+
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  padding: 2.1rem 2.8rem;
+  border-radius: 0.4rem 0.4rem 0rem 0rem;
+  background: #f2f2f2;
+}
+
+.c4 {
+  font-size: 20px;
+  line-height: 30px;
+  color: #333333;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c10 {
+  padding: 2.1rem 2.8rem;
+  justify-self: flex-end;
+  border-top: none;
+}
+
 .c2 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -2955,55 +3004,6 @@ exports[`Modal with size small with a left panel 1`] = `
   opacity: 0;
   -webkit-transition: opacity 100ms ease-out;
   transition: opacity 100ms ease-out;
-}
-
-.c3 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  padding: 2.1rem 2.8rem;
-  border-radius: 0.4rem 0.4rem 0rem 0rem;
-  background: #f2f2f2;
-}
-
-.c4 {
-  font-size: 20px;
-  line-height: 30px;
-  color: #333333;
-}
-
-.c5 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  -webkit-box-pack: end;
-  -webkit-justify-content: flex-end;
-  -ms-flex-pack: end;
-  justify-content: flex-end;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.c9 {
-  padding: 2.1rem 2.8rem 0rem;
-  overflow-y: auto;
-  -webkit-flex: 1 1 auto;
-  -ms-flex: 1 1 auto;
-  flex: 1 1 auto;
-}
-
-.c10 {
-  padding: 2.1rem 2.8rem;
-  justify-self: flex-end;
-  border-top: none;
 }
 
 <div
@@ -3106,6 +3106,55 @@ exports[`Modal with size small with a left panel 1`] = `
 `;
 
 exports[`Modal with size small with a right panel 1`] = `
+.c8 {
+  padding: 2.1rem 2.8rem 0rem;
+  overflow-y: auto;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+}
+
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  padding: 2.1rem 2.8rem;
+  border-radius: 0.4rem 0.4rem 0rem 0rem;
+  background: #f2f2f2;
+}
+
+.c4 {
+  font-size: 20px;
+  line-height: 30px;
+  color: #333333;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c9 {
+  padding: 2.1rem 2.8rem;
+  justify-self: flex-end;
+  border-top: none;
+}
+
 .c2 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -3242,55 +3291,6 @@ exports[`Modal with size small with a right panel 1`] = `
   transition: opacity 100ms ease-out;
 }
 
-.c3 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  padding: 2.1rem 2.8rem;
-  border-radius: 0.4rem 0.4rem 0rem 0rem;
-  background: #f2f2f2;
-}
-
-.c4 {
-  font-size: 20px;
-  line-height: 30px;
-  color: #333333;
-}
-
-.c5 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  -webkit-box-pack: end;
-  -webkit-justify-content: flex-end;
-  -ms-flex-pack: end;
-  justify-content: flex-end;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.c8 {
-  padding: 2.1rem 2.8rem 0rem;
-  overflow-y: auto;
-  -webkit-flex: 1 1 auto;
-  -ms-flex: 1 1 auto;
-  flex: 1 1 auto;
-}
-
-.c9 {
-  padding: 2.1rem 2.8rem;
-  justify-self: flex-end;
-  border-top: none;
-}
-
 <div
   class="rc-dialog-wrap "
   role="dialog"
@@ -3391,6 +3391,55 @@ exports[`Modal with size small with a right panel 1`] = `
 `;
 
 exports[`Modal with size small with right section in header 1`] = `
+.c6 {
+  padding: 2.1rem 2.8rem 0rem;
+  overflow-y: auto;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+}
+
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  padding: 2.1rem 2.8rem;
+  border-radius: 0.4rem 0.4rem 0rem 0rem;
+  background: #f2f2f2;
+}
+
+.c4 {
+  font-size: 20px;
+  line-height: 30px;
+  color: #333333;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c7 {
+  padding: 2.1rem 2.8rem;
+  justify-self: flex-end;
+  border-top: none;
+}
+
 .c2 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -3489,55 +3538,6 @@ exports[`Modal with size small with right section in header 1`] = `
   opacity: 0;
   -webkit-transition: opacity 100ms ease-out;
   transition: opacity 100ms ease-out;
-}
-
-.c3 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  padding: 2.1rem 2.8rem;
-  border-radius: 0.4rem 0.4rem 0rem 0rem;
-  background: #f2f2f2;
-}
-
-.c4 {
-  font-size: 20px;
-  line-height: 30px;
-  color: #333333;
-}
-
-.c5 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  -webkit-box-pack: end;
-  -webkit-justify-content: flex-end;
-  -ms-flex-pack: end;
-  justify-content: flex-end;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.c6 {
-  padding: 2.1rem 2.8rem 0rem;
-  overflow-y: auto;
-  -webkit-flex: 1 1 auto;
-  -ms-flex: 1 1 auto;
-  flex: 1 1 auto;
-}
-
-.c7 {
-  padding: 2.1rem 2.8rem;
-  justify-self: flex-end;
-  border-top: none;
 }
 
 <div
@@ -3631,6 +3631,55 @@ exports[`Modal with size small with right section in header 1`] = `
 `;
 
 exports[`Modal with size small with simple config 1`] = `
+.c6 {
+  padding: 2.1rem 2.8rem 0rem;
+  overflow-y: auto;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+}
+
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  padding: 2.1rem 2.8rem;
+  border-radius: 0.4rem 0.4rem 0rem 0rem;
+  background: #f2f2f2;
+}
+
+.c4 {
+  font-size: 20px;
+  line-height: 30px;
+  color: #333333;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c7 {
+  padding: 2.1rem 2.8rem;
+  justify-self: flex-end;
+  border-top: none;
+}
+
 .c2 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -3731,55 +3780,6 @@ exports[`Modal with size small with simple config 1`] = `
   transition: opacity 100ms ease-out;
 }
 
-.c3 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  padding: 2.1rem 2.8rem;
-  border-radius: 0.4rem 0.4rem 0rem 0rem;
-  background: #f2f2f2;
-}
-
-.c4 {
-  font-size: 20px;
-  line-height: 30px;
-  color: #333333;
-}
-
-.c5 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  -webkit-box-pack: end;
-  -webkit-justify-content: flex-end;
-  -ms-flex-pack: end;
-  justify-content: flex-end;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.c6 {
-  padding: 2.1rem 2.8rem 0rem;
-  overflow-y: auto;
-  -webkit-flex: 1 1 auto;
-  -ms-flex: 1 1 auto;
-  flex: 1 1 auto;
-}
-
-.c7 {
-  padding: 2.1rem 2.8rem;
-  justify-self: flex-end;
-  border-top: none;
-}
-
 <div
   class="rc-dialog-wrap "
   role="dialog"
@@ -3865,6 +3865,55 @@ exports[`Modal with size small with simple config 1`] = `
 `;
 
 exports[`Modal with size x-large with a bottom panel 1`] = `
+.c6 {
+  padding: 2.1rem 2.8rem 0rem;
+  overflow-y: auto;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+}
+
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  padding: 2.1rem 2.8rem;
+  border-radius: 0.4rem 0.4rem 0rem 0rem;
+  background: #f2f2f2;
+}
+
+.c4 {
+  font-size: 20px;
+  line-height: 30px;
+  color: #333333;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c7 {
+  padding: 2.1rem 2.8rem;
+  justify-self: flex-end;
+  border-top: none;
+}
+
 .c2 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -3971,55 +4020,6 @@ exports[`Modal with size x-large with a bottom panel 1`] = `
   transition: opacity 100ms ease-out;
 }
 
-.c3 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  padding: 2.1rem 2.8rem;
-  border-radius: 0.4rem 0.4rem 0rem 0rem;
-  background: #f2f2f2;
-}
-
-.c4 {
-  font-size: 20px;
-  line-height: 30px;
-  color: #333333;
-}
-
-.c5 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  -webkit-box-pack: end;
-  -webkit-justify-content: flex-end;
-  -ms-flex-pack: end;
-  justify-content: flex-end;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.c6 {
-  padding: 2.1rem 2.8rem 0rem;
-  overflow-y: auto;
-  -webkit-flex: 1 1 auto;
-  -ms-flex: 1 1 auto;
-  flex: 1 1 auto;
-}
-
-.c7 {
-  padding: 2.1rem 2.8rem;
-  justify-self: flex-end;
-  border-top: none;
-}
-
 <div
   class="rc-dialog-wrap "
   role="dialog"
@@ -4112,6 +4112,55 @@ exports[`Modal with size x-large with a bottom panel 1`] = `
 `;
 
 exports[`Modal with size x-large with a left panel 1`] = `
+.c9 {
+  padding: 2.1rem 2.8rem 0rem;
+  overflow-y: auto;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+}
+
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  padding: 2.1rem 2.8rem;
+  border-radius: 0.4rem 0.4rem 0rem 0rem;
+  background: #f2f2f2;
+}
+
+.c4 {
+  font-size: 20px;
+  line-height: 30px;
+  color: #333333;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c10 {
+  padding: 2.1rem 2.8rem;
+  justify-self: flex-end;
+  border-top: none;
+}
+
 .c2 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -4245,55 +4294,6 @@ exports[`Modal with size x-large with a left panel 1`] = `
   transition: opacity 100ms ease-out;
 }
 
-.c3 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  padding: 2.1rem 2.8rem;
-  border-radius: 0.4rem 0.4rem 0rem 0rem;
-  background: #f2f2f2;
-}
-
-.c4 {
-  font-size: 20px;
-  line-height: 30px;
-  color: #333333;
-}
-
-.c5 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  -webkit-box-pack: end;
-  -webkit-justify-content: flex-end;
-  -ms-flex-pack: end;
-  justify-content: flex-end;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.c9 {
-  padding: 2.1rem 2.8rem 0rem;
-  overflow-y: auto;
-  -webkit-flex: 1 1 auto;
-  -ms-flex: 1 1 auto;
-  flex: 1 1 auto;
-}
-
-.c10 {
-  padding: 2.1rem 2.8rem;
-  justify-self: flex-end;
-  border-top: none;
-}
-
 <div
   class="rc-dialog-wrap "
   role="dialog"
@@ -4394,6 +4394,55 @@ exports[`Modal with size x-large with a left panel 1`] = `
 `;
 
 exports[`Modal with size x-large with a right panel 1`] = `
+.c8 {
+  padding: 2.1rem 2.8rem 0rem;
+  overflow-y: auto;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+}
+
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  padding: 2.1rem 2.8rem;
+  border-radius: 0.4rem 0.4rem 0rem 0rem;
+  background: #f2f2f2;
+}
+
+.c4 {
+  font-size: 20px;
+  line-height: 30px;
+  color: #333333;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c9 {
+  padding: 2.1rem 2.8rem;
+  justify-self: flex-end;
+  border-top: none;
+}
+
 .c2 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -4530,55 +4579,6 @@ exports[`Modal with size x-large with a right panel 1`] = `
   transition: opacity 100ms ease-out;
 }
 
-.c3 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  padding: 2.1rem 2.8rem;
-  border-radius: 0.4rem 0.4rem 0rem 0rem;
-  background: #f2f2f2;
-}
-
-.c4 {
-  font-size: 20px;
-  line-height: 30px;
-  color: #333333;
-}
-
-.c5 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  -webkit-box-pack: end;
-  -webkit-justify-content: flex-end;
-  -ms-flex-pack: end;
-  justify-content: flex-end;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.c8 {
-  padding: 2.1rem 2.8rem 0rem;
-  overflow-y: auto;
-  -webkit-flex: 1 1 auto;
-  -ms-flex: 1 1 auto;
-  flex: 1 1 auto;
-}
-
-.c9 {
-  padding: 2.1rem 2.8rem;
-  justify-self: flex-end;
-  border-top: none;
-}
-
 <div
   class="rc-dialog-wrap "
   role="dialog"
@@ -4679,6 +4679,55 @@ exports[`Modal with size x-large with a right panel 1`] = `
 `;
 
 exports[`Modal with size x-large with right section in header 1`] = `
+.c6 {
+  padding: 2.1rem 2.8rem 0rem;
+  overflow-y: auto;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+}
+
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  padding: 2.1rem 2.8rem;
+  border-radius: 0.4rem 0.4rem 0rem 0rem;
+  background: #f2f2f2;
+}
+
+.c4 {
+  font-size: 20px;
+  line-height: 30px;
+  color: #333333;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c7 {
+  padding: 2.1rem 2.8rem;
+  justify-self: flex-end;
+  border-top: none;
+}
+
 .c2 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -4777,55 +4826,6 @@ exports[`Modal with size x-large with right section in header 1`] = `
   opacity: 0;
   -webkit-transition: opacity 100ms ease-out;
   transition: opacity 100ms ease-out;
-}
-
-.c3 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  padding: 2.1rem 2.8rem;
-  border-radius: 0.4rem 0.4rem 0rem 0rem;
-  background: #f2f2f2;
-}
-
-.c4 {
-  font-size: 20px;
-  line-height: 30px;
-  color: #333333;
-}
-
-.c5 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  -webkit-box-pack: end;
-  -webkit-justify-content: flex-end;
-  -ms-flex-pack: end;
-  justify-content: flex-end;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.c6 {
-  padding: 2.1rem 2.8rem 0rem;
-  overflow-y: auto;
-  -webkit-flex: 1 1 auto;
-  -ms-flex: 1 1 auto;
-  flex: 1 1 auto;
-}
-
-.c7 {
-  padding: 2.1rem 2.8rem;
-  justify-self: flex-end;
-  border-top: none;
 }
 
 <div
@@ -4919,6 +4919,55 @@ exports[`Modal with size x-large with right section in header 1`] = `
 `;
 
 exports[`Modal with size x-large with simple config 1`] = `
+.c6 {
+  padding: 2.1rem 2.8rem 0rem;
+  overflow-y: auto;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+}
+
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  padding: 2.1rem 2.8rem;
+  border-radius: 0.4rem 0.4rem 0rem 0rem;
+  background: #f2f2f2;
+}
+
+.c4 {
+  font-size: 20px;
+  line-height: 30px;
+  color: #333333;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c7 {
+  padding: 2.1rem 2.8rem;
+  justify-self: flex-end;
+  border-top: none;
+}
+
 .c2 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -5017,55 +5066,6 @@ exports[`Modal with size x-large with simple config 1`] = `
   opacity: 0;
   -webkit-transition: opacity 100ms ease-out;
   transition: opacity 100ms ease-out;
-}
-
-.c3 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  padding: 2.1rem 2.8rem;
-  border-radius: 0.4rem 0.4rem 0rem 0rem;
-  background: #f2f2f2;
-}
-
-.c4 {
-  font-size: 20px;
-  line-height: 30px;
-  color: #333333;
-}
-
-.c5 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  -webkit-box-pack: end;
-  -webkit-justify-content: flex-end;
-  -ms-flex-pack: end;
-  justify-content: flex-end;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.c6 {
-  padding: 2.1rem 2.8rem 0rem;
-  overflow-y: auto;
-  -webkit-flex: 1 1 auto;
-  -ms-flex: 1 1 auto;
-  flex: 1 1 auto;
-}
-
-.c7 {
-  padding: 2.1rem 2.8rem;
-  justify-self: flex-end;
-  border-top: none;
 }
 
 <div

--- a/components/Modal/components/Footer.tsx
+++ b/components/Modal/components/Footer.tsx
@@ -1,21 +1,16 @@
-import React, { ReactNode } from "react"
 import styled from "styled-components"
 import { border, padding } from "../common/styles"
+import { IStyled } from "../../common/types"
 
-const Footer = ({
-  children,
-  showBorder,
-}: {
-  children: ReactNode
+interface FooterProps {
   showBorder: boolean
-}) => {
-  const StyledDiv = styled.div`
-    padding: ${`${padding.vertical} ${padding.horizontal}`};
-    justify-self: flex-end;
-    border-top: ${showBorder ? border : `none`};
-  `
-
-  return <StyledDiv>{children}</StyledDiv>
 }
+
+const Footer = styled.div<IStyled<FooterProps>>`
+  padding: ${`${padding.vertical} ${padding.horizontal}`};
+  justify-self: flex-end;
+  border-top: ${({ customProps: { showBorder } }) =>
+    showBorder ? border : `none`};
+`
 
 export default Footer

--- a/components/Modal/components/Header.tsx
+++ b/components/Modal/components/Header.tsx
@@ -2,43 +2,35 @@ import React, { ReactNode } from "react"
 import styled from "styled-components"
 import { borderRadius, padding } from "../common/styles"
 
+const Container = styled.div`
+  display: flex;
+  padding: ${`${padding.vertical} ${padding.horizontal}`};
+  border-radius: ${`${borderRadius} ${borderRadius} 0rem 0rem`};
+  background: ${({ theme }) => theme.shades.gray95};
+`
+const TitleSection = styled.div`
+  font-size: 20px;
+  line-height: 30px;
+  color: ${({ theme }) => theme.shades.gray20};
+`
+
+const RightSection = styled.div`
+  display: flex;
+  flex-grow: 1;
+  justify-content: flex-end;
+  align-items: center;
+`
+
 interface HeaderProps {
   title: string
   rightSection?: ReactNode
 }
 
-const Header: React.FC<HeaderProps> = ({
-  title,
-  rightSection,
-}: {
-  title: string
-  rightSection: ReactNode
-}) => {
-  const Container = styled.div`
-    display: flex;
-    padding: ${`${padding.vertical} ${padding.horizontal}`};
-    border-radius: ${`${borderRadius} ${borderRadius} 0rem 0rem`};
-    background: ${props => props.theme.shades.gray95};
-  `
-  const TitleSection = styled.div`
-    font-size: 20px;
-    line-height: 30px;
-    color: ${props => props.theme.shades.gray20};
-  `
-
-  const RightSection = styled.div`
-    display: flex;
-    flex-grow: 1;
-    justify-content: flex-end;
-    align-items: center;
-  `
-
-  return (
-    <Container>
-      <TitleSection>{title}</TitleSection>
-      <RightSection>{rightSection}</RightSection>
-    </Container>
-  )
-}
+const Header: React.FC<HeaderProps> = ({ title, rightSection }) => (
+  <Container>
+    <TitleSection>{title}</TitleSection>
+    <RightSection>{rightSection}</RightSection>
+  </Container>
+)
 
 export default Header

--- a/components/Modal/components/Main.tsx
+++ b/components/Modal/components/Main.tsx
@@ -1,19 +1,10 @@
-import React, { ReactNode } from "react"
 import styled from "styled-components"
 import { padding } from "../common/styles"
 
-export default ({
-  children,
-  setBodyRef,
-}: {
-  children: ReactNode
-  setBodyRef: (instance: HTMLDivElement | null) => void
-}) => {
-  const Main = styled.div`
-    padding: ${`${padding.vertical} ${padding.horizontal} 0rem`};
-    overflow-y: auto;
-    flex: 1 1 auto;
-  `
+const Main = styled.div`
+  padding: ${`${padding.vertical} ${padding.horizontal} 0rem`};
+  overflow-y: auto;
+  flex: 1 1 auto;
+`
 
-  return <Main ref={setBodyRef}>{children}</Main>
-}
+export default Main

--- a/components/Switch/styledComponents.tsx
+++ b/components/Switch/styledComponents.tsx
@@ -74,12 +74,8 @@ export const StyledSwitch = styled(RCSwitch)`
       &:after {
         left: ${({ theme, size }) =>
           isSmall(size)
-            ? `calc(${theme.switchWrapperWidthSm} - ${
-                theme.switchTrackerWidthSm
-              } - 2px)`
-            : `calc(${theme.switchWrapperWidth} - ${
-                theme.switchTrackerWidth
-              } - 2px)`};
+            ? `calc(${theme.switchWrapperWidthSm} - ${theme.switchTrackerWidthSm} - 2px)`
+            : `calc(${theme.switchWrapperWidth} - ${theme.switchTrackerWidth} - 2px)`};
       }
     }
 

--- a/components/common/types.ts
+++ b/components/common/types.ts
@@ -1,0 +1,7 @@
+export interface IStyled<PropType> {
+  customProps: {
+    showBorder: PropType
+  }
+  theme: any
+  [htmlProp: string]: any
+}

--- a/components/common/types.ts
+++ b/components/common/types.ts
@@ -1,7 +1,5 @@
 export interface IStyled<PropType> {
-  customProps: {
-    showBorder: PropType
-  }
+  customProps: PropType
   theme: any
   [htmlProp: string]: any
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "knit-ui",
-  "version": "0.2.4",
+  "version": "0.3.4",
   "description": "Component library for Clarisights",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8430,6 +8430,11 @@ prettier@^1.16.4:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.17.1.tgz#ed64b4e93e370cb8a25b9ef7fef3e4fd1c0995db"
   integrity sha512-TzGRNvuUSmPgwivDqkZ9tM/qTGW9hqDKWOE9YHiyQdixlKbv7kvEqsmDPrcHJTKwthU774TQwZXVtaQ/mMsvjg==
 
+prettier@^1.17.1:
+  version "1.18.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.18.2.tgz#6823e7c5900017b4bd3acf46fe9ac4b4d7bda9ea"
+  integrity sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==
+
 pretty-error@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/pretty-error/-/pretty-error-2.1.1.tgz#5f4f87c8f91e5ae3f3ba87ab4cf5e03b1a17f1a3"


### PR DESCRIPTION
## Story

https://app.clubhouse.io/clarisights/story/10999/knitui-move-styled-components-out-of-render

## Description

- Moves styled components out of render methods to avoid performance issues
- Implements a pattern of passing of custom props separately for styled components to avoid them being applied on the DOM. When passing props to Styled components, use the format below:
```javascript
   props = {
      customProps: { /* props that should not be applied on the DOM node */ },
      ...
      /* props that should be applied on the DOM node */
   }
```