### PR TITLE
Fix style issues in the focus and active states of the button

### DIFF
--- a/src/components/Button/__tests__/__snapshots__/Button.test.tsx.snap
+++ b/src/components/Button/__tests__/__snapshots__/Button.test.tsx.snap
@@ -36,6 +36,7 @@ exports[`Button renders with a custom color theme correctly 1`] = `
 .c0:hover,
 .c0:active,
 .c0:focus {
+  color: #1a1a1a;
   background-color: #ed12f1;
 }
 
@@ -47,17 +48,13 @@ exports[`Button renders with a custom color theme correctly 1`] = `
 
 .c0:active,
 .c0:focus {
-  border: 1px solid #5ab2f2;
-}
-
-.c0:active svg path,
-.c0:focus svg path {
-  fill: #1a1a1a;
+  border: 1px solid #5ab2f2 !important;
+  box-shadow: 0px 0px 2px hsl(216,100%,50%);
+  outline: none;
 }
 
 .c0:hover {
   border: 1px solid #00000000;
-  color: #1a1a1a;
 }
 
 .c0:disabled {
@@ -109,6 +106,7 @@ exports[`Button renders with a custom color theme correctly 2`] = `
 .c0:hover,
 .c0:active,
 .c0:focus {
+  color: #1a1a1a;
   background-color: #ed12f1;
 }
 
@@ -120,17 +118,13 @@ exports[`Button renders with a custom color theme correctly 2`] = `
 
 .c0:active,
 .c0:focus {
-  border: 1px solid #5ab2f2;
-}
-
-.c0:active svg path,
-.c0:focus svg path {
-  fill: #1a1a1a;
+  border: 1px solid #5ab2f2 !important;
+  box-shadow: 0px 0px 2px hsl(216,100%,50%);
+  outline: none;
 }
 
 .c0:hover {
   border: 1px solid #00000000;
-  color: #1a1a1a;
 }
 
 .c0:disabled {
@@ -182,6 +176,7 @@ exports[`Button renders with a custom color theme correctly 3`] = `
 .c0:hover,
 .c0:active,
 .c0:focus {
+  color: #1a1a1a;
   background-color: #ed12f1;
 }
 
@@ -193,17 +188,13 @@ exports[`Button renders with a custom color theme correctly 3`] = `
 
 .c0:active,
 .c0:focus {
-  border: 1px solid #5ab2f2;
-}
-
-.c0:active svg path,
-.c0:focus svg path {
-  fill: #1a1a1a;
+  border: 1px solid #5ab2f2 !important;
+  box-shadow: 0px 0px 2px hsl(216,100%,50%);
+  outline: none;
 }
 
 .c0:hover {
   border: 1px solid #00000000;
-  color: #1a1a1a;
 }
 
 .c0:disabled {
@@ -255,6 +246,7 @@ exports[`Button renders with a specified color preset correctly 1`] = `
 .c0:hover,
 .c0:active,
 .c0:focus {
+  color: #ffffff;
   background-color: #cc0000;
 }
 
@@ -266,17 +258,13 @@ exports[`Button renders with a specified color preset correctly 1`] = `
 
 .c0:active,
 .c0:focus {
-  border: 1px solid #5ab2f2;
-}
-
-.c0:active svg path,
-.c0:focus svg path {
-  fill: #ffffff;
+  border: 1px solid #5ab2f2 !important;
+  box-shadow: 0px 0px 2px hsl(216,100%,50%);
+  outline: none;
 }
 
 .c0:hover {
   border: 1px solid #00000000;
-  color: #ffffff;
 }
 
 .c0:disabled {
@@ -328,6 +316,7 @@ exports[`Button renders with a specified color preset correctly 2`] = `
 .c0:hover,
 .c0:active,
 .c0:focus {
+  color: #ffffff;
   background-color: #cc0000;
 }
 
@@ -339,17 +328,13 @@ exports[`Button renders with a specified color preset correctly 2`] = `
 
 .c0:active,
 .c0:focus {
-  border: 1px solid #5ab2f2;
-}
-
-.c0:active svg path,
-.c0:focus svg path {
-  fill: #ffffff;
+  border: 1px solid #5ab2f2 !important;
+  box-shadow: 0px 0px 2px hsl(216,100%,50%);
+  outline: none;
 }
 
 .c0:hover {
   border: 1px solid #00000000;
-  color: #ffffff;
 }
 
 .c0:disabled {
@@ -401,6 +386,7 @@ exports[`Button renders with a specified color preset correctly 3`] = `
 .c0:hover,
 .c0:active,
 .c0:focus {
+  color: #ffffff;
   background-color: #cc0000;
 }
 
@@ -412,17 +398,13 @@ exports[`Button renders with a specified color preset correctly 3`] = `
 
 .c0:active,
 .c0:focus {
-  border: 1px solid #5ab2f2;
-}
-
-.c0:active svg path,
-.c0:focus svg path {
-  fill: #ffffff;
+  border: 1px solid #5ab2f2 !important;
+  box-shadow: 0px 0px 2px hsl(216,100%,50%);
+  outline: none;
 }
 
 .c0:hover {
   border: 1px solid #00000000;
-  color: #ffffff;
 }
 
 .c0:disabled {
@@ -474,6 +456,7 @@ exports[`Button renders with inset correctly 1`] = `
 .c0:hover,
 .c0:active,
 .c0:focus {
+  color: #ffffff;
   background-color: #003d99;
 }
 
@@ -485,17 +468,13 @@ exports[`Button renders with inset correctly 1`] = `
 
 .c0:active,
 .c0:focus {
-  border: 1px solid #5ab2f2;
-}
-
-.c0:active svg path,
-.c0:focus svg path {
-  fill: #ffffff;
+  border: 1px solid #5ab2f2 !important;
+  box-shadow: 0px 0px 2px hsl(216,100%,50%);
+  outline: none;
 }
 
 .c0:hover {
   border: 1px solid #00000000;
-  color: #ffffff;
 }
 
 .c0:disabled {
@@ -566,6 +545,7 @@ exports[`Button renders with inset correctly 2`] = `
 .c0:hover,
 .c0:active,
 .c0:focus {
+  color: #ffffff;
   background-color: #003d99;
 }
 
@@ -577,17 +557,13 @@ exports[`Button renders with inset correctly 2`] = `
 
 .c0:active,
 .c0:focus {
-  border: 1px solid #5ab2f2;
-}
-
-.c0:active svg path,
-.c0:focus svg path {
-  fill: #ffffff;
+  border: 1px solid #5ab2f2 !important;
+  box-shadow: 0px 0px 2px hsl(216,100%,50%);
+  outline: none;
 }
 
 .c0:hover {
   border: 1px solid #00000000;
-  color: #ffffff;
 }
 
 .c0:disabled {
@@ -658,6 +634,7 @@ exports[`Button renders with inset correctly 3`] = `
 .c0:hover,
 .c0:active,
 .c0:focus {
+  color: #ffffff;
   background-color: #003d99;
 }
 
@@ -669,17 +646,13 @@ exports[`Button renders with inset correctly 3`] = `
 
 .c0:active,
 .c0:focus {
-  border: 1px solid #5ab2f2;
-}
-
-.c0:active svg path,
-.c0:focus svg path {
-  fill: #ffffff;
+  border: 1px solid #5ab2f2 !important;
+  box-shadow: 0px 0px 2px hsl(216,100%,50%);
+  outline: none;
 }
 
 .c0:hover {
   border: 1px solid #00000000;
-  color: #ffffff;
 }
 
 .c0:disabled {
@@ -757,6 +730,7 @@ exports[`Button renders with text and an icon correctly 1`] = `
 .c0:hover,
 .c0:active,
 .c0:focus {
+  color: #ffffff;
   background-color: #003d99;
 }
 
@@ -768,17 +742,13 @@ exports[`Button renders with text and an icon correctly 1`] = `
 
 .c0:active,
 .c0:focus {
-  border: 1px solid #5ab2f2;
-}
-
-.c0:active svg path,
-.c0:focus svg path {
-  fill: #ffffff;
+  border: 1px solid #5ab2f2 !important;
+  box-shadow: 0px 0px 2px hsl(216,100%,50%);
+  outline: none;
 }
 
 .c0:hover {
   border: 1px solid #00000000;
-  color: #ffffff;
 }
 
 .c0:disabled {
@@ -855,6 +825,7 @@ exports[`Button renders with text and an icon correctly 2`] = `
 .c0:hover,
 .c0:active,
 .c0:focus {
+  color: #ffffff;
   background-color: #003d99;
 }
 
@@ -866,17 +837,13 @@ exports[`Button renders with text and an icon correctly 2`] = `
 
 .c0:active,
 .c0:focus {
-  border: 1px solid #5ab2f2;
-}
-
-.c0:active svg path,
-.c0:focus svg path {
-  fill: #ffffff;
+  border: 1px solid #5ab2f2 !important;
+  box-shadow: 0px 0px 2px hsl(216,100%,50%);
+  outline: none;
 }
 
 .c0:hover {
   border: 1px solid #00000000;
-  color: #ffffff;
 }
 
 .c0:disabled {
@@ -953,6 +920,7 @@ exports[`Button renders with text and an icon correctly 3`] = `
 .c0:hover,
 .c0:active,
 .c0:focus {
+  color: #ffffff;
   background-color: #003d99;
 }
 
@@ -964,17 +932,13 @@ exports[`Button renders with text and an icon correctly 3`] = `
 
 .c0:active,
 .c0:focus {
-  border: 1px solid #5ab2f2;
-}
-
-.c0:active svg path,
-.c0:focus svg path {
-  fill: #ffffff;
+  border: 1px solid #5ab2f2 !important;
+  box-shadow: 0px 0px 2px hsl(216,100%,50%);
+  outline: none;
 }
 
 .c0:hover {
   border: 1px solid #00000000;
-  color: #ffffff;
 }
 
 .c0:disabled {
@@ -1051,6 +1015,7 @@ exports[`Button renders with text, icon and inset correctly 1`] = `
 .c0:hover,
 .c0:active,
 .c0:focus {
+  color: #ffffff;
   background-color: #003d99;
 }
 
@@ -1062,17 +1027,13 @@ exports[`Button renders with text, icon and inset correctly 1`] = `
 
 .c0:active,
 .c0:focus {
-  border: 1px solid #5ab2f2;
-}
-
-.c0:active svg path,
-.c0:focus svg path {
-  fill: #ffffff;
+  border: 1px solid #5ab2f2 !important;
+  box-shadow: 0px 0px 2px hsl(216,100%,50%);
+  outline: none;
 }
 
 .c0:hover {
   border: 1px solid #00000000;
-  color: #ffffff;
 }
 
 .c0:disabled {
@@ -1168,6 +1129,7 @@ exports[`Button renders with text, icon and inset correctly 2`] = `
 .c0:hover,
 .c0:active,
 .c0:focus {
+  color: #ffffff;
   background-color: #003d99;
 }
 
@@ -1179,17 +1141,13 @@ exports[`Button renders with text, icon and inset correctly 2`] = `
 
 .c0:active,
 .c0:focus {
-  border: 1px solid #5ab2f2;
-}
-
-.c0:active svg path,
-.c0:focus svg path {
-  fill: #ffffff;
+  border: 1px solid #5ab2f2 !important;
+  box-shadow: 0px 0px 2px hsl(216,100%,50%);
+  outline: none;
 }
 
 .c0:hover {
   border: 1px solid #00000000;
-  color: #ffffff;
 }
 
 .c0:disabled {
@@ -1285,6 +1243,7 @@ exports[`Button renders with text, icon and inset correctly 3`] = `
 .c0:hover,
 .c0:active,
 .c0:focus {
+  color: #ffffff;
   background-color: #003d99;
 }
 
@@ -1296,17 +1255,13 @@ exports[`Button renders with text, icon and inset correctly 3`] = `
 
 .c0:active,
 .c0:focus {
-  border: 1px solid #5ab2f2;
-}
-
-.c0:active svg path,
-.c0:focus svg path {
-  fill: #ffffff;
+  border: 1px solid #5ab2f2 !important;
+  box-shadow: 0px 0px 2px hsl(216,100%,50%);
+  outline: none;
 }
 
 .c0:hover {
   border: 1px solid #00000000;
-  color: #ffffff;
 }
 
 .c0:disabled {
@@ -1395,28 +1350,25 @@ exports[`Button with size large renders a bare variant correctly 1`] = `
 .c0:hover,
 .c0:active,
 .c0:focus {
+  color: #003d99;
   background-color: #f2f2f2;
 }
 
 .c0:hover svg path,
 .c0:active svg path,
 .c0:focus svg path {
-  fill: #002966;
+  fill: #003d99;
 }
 
 .c0:active,
 .c0:focus {
-  border: 1px solid #5ab2f2;
-}
-
-.c0:active svg path,
-.c0:focus svg path {
-  fill: #b3b3b3;
+  border: 1px solid #5ab2f2 !important;
+  box-shadow: 0px 0px 2px hsl(216,100%,50%);
+  outline: none;
 }
 
 .c0:hover {
   border: 1px solid #00000000;
-  color: #003d99;
 }
 
 .c0:disabled {
@@ -1468,6 +1420,7 @@ exports[`Button with size large renders a ghost variant correctly 1`] = `
 .c0:hover,
 .c0:active,
 .c0:focus {
+  color: #0066ff;
   background-color: #ffffff;
 }
 
@@ -1479,17 +1432,13 @@ exports[`Button with size large renders a ghost variant correctly 1`] = `
 
 .c0:active,
 .c0:focus {
-  border: 1px solid #002966;
-}
-
-.c0:active svg path,
-.c0:focus svg path {
-  fill: #0066ff;
+  border: 1px solid #5ab2f2 !important;
+  box-shadow: 0px 0px 2px hsl(216,100%,50%);
+  outline: none;
 }
 
 .c0:hover {
   border: 1px solid #0066ff;
-  color: #0066ff;
 }
 
 .c0:disabled {
@@ -1541,6 +1490,7 @@ exports[`Button with size large renders a primary variant with a label correctly
 .c0:hover,
 .c0:active,
 .c0:focus {
+  color: #ffffff;
   background-color: #003d99;
 }
 
@@ -1552,17 +1502,13 @@ exports[`Button with size large renders a primary variant with a label correctly
 
 .c0:active,
 .c0:focus {
-  border: 1px solid #5ab2f2;
-}
-
-.c0:active svg path,
-.c0:focus svg path {
-  fill: #ffffff;
+  border: 1px solid #5ab2f2 !important;
+  box-shadow: 0px 0px 2px hsl(216,100%,50%);
+  outline: none;
 }
 
 .c0:hover {
   border: 1px solid #00000000;
-  color: #ffffff;
 }
 
 .c0:disabled {
@@ -1614,6 +1560,7 @@ exports[`Button with size large renders a primary variant with a label correctly
 .c0:hover,
 .c0:active,
 .c0:focus {
+  color: #ffffff;
   background-color: #003d99;
 }
 
@@ -1625,17 +1572,13 @@ exports[`Button with size large renders a primary variant with a label correctly
 
 .c0:active,
 .c0:focus {
-  border: 1px solid #5ab2f2;
-}
-
-.c0:active svg path,
-.c0:focus svg path {
-  fill: #ffffff;
+  border: 1px solid #5ab2f2 !important;
+  box-shadow: 0px 0px 2px hsl(216,100%,50%);
+  outline: none;
 }
 
 .c0:hover {
   border: 1px solid #00000000;
-  color: #ffffff;
 }
 
 .c0:disabled {
@@ -1694,28 +1637,25 @@ exports[`Button with size large renders with a bare icon correctly 1`] = `
 .c0:hover,
 .c0:active,
 .c0:focus {
+  color: #003d99;
   background-color: #f2f2f2;
 }
 
 .c0:hover svg path,
 .c0:active svg path,
 .c0:focus svg path {
-  fill: #002966;
+  fill: #003d99;
 }
 
 .c0:active,
 .c0:focus {
-  border: 1px solid #5ab2f2;
-}
-
-.c0:active svg path,
-.c0:focus svg path {
-  fill: #b3b3b3;
+  border: 1px solid #5ab2f2 !important;
+  box-shadow: 0px 0px 2px hsl(216,100%,50%);
+  outline: none;
 }
 
 .c0:hover {
   border: 1px solid #00000000;
-  color: #003d99;
 }
 
 .c0:disabled {
@@ -1792,6 +1732,7 @@ exports[`Button with size large renders with an icon correctly 1`] = `
 .c0:hover,
 .c0:active,
 .c0:focus {
+  color: #ffffff;
   background-color: #003d99;
 }
 
@@ -1803,17 +1744,13 @@ exports[`Button with size large renders with an icon correctly 1`] = `
 
 .c0:active,
 .c0:focus {
-  border: 1px solid #5ab2f2;
-}
-
-.c0:active svg path,
-.c0:focus svg path {
-  fill: #ffffff;
+  border: 1px solid #5ab2f2 !important;
+  box-shadow: 0px 0px 2px hsl(216,100%,50%);
+  outline: none;
 }
 
 .c0:hover {
   border: 1px solid #00000000;
-  color: #ffffff;
 }
 
 .c0:disabled {
@@ -1883,28 +1820,25 @@ exports[`Button with size medium renders a bare variant correctly 1`] = `
 .c0:hover,
 .c0:active,
 .c0:focus {
+  color: #003d99;
   background-color: #f2f2f2;
 }
 
 .c0:hover svg path,
 .c0:active svg path,
 .c0:focus svg path {
-  fill: #002966;
+  fill: #003d99;
 }
 
 .c0:active,
 .c0:focus {
-  border: 1px solid #5ab2f2;
-}
-
-.c0:active svg path,
-.c0:focus svg path {
-  fill: #b3b3b3;
+  border: 1px solid #5ab2f2 !important;
+  box-shadow: 0px 0px 2px hsl(216,100%,50%);
+  outline: none;
 }
 
 .c0:hover {
   border: 1px solid #00000000;
-  color: #003d99;
 }
 
 .c0:disabled {
@@ -1956,6 +1890,7 @@ exports[`Button with size medium renders a ghost variant correctly 1`] = `
 .c0:hover,
 .c0:active,
 .c0:focus {
+  color: #0066ff;
   background-color: #ffffff;
 }
 
@@ -1967,17 +1902,13 @@ exports[`Button with size medium renders a ghost variant correctly 1`] = `
 
 .c0:active,
 .c0:focus {
-  border: 1px solid #002966;
-}
-
-.c0:active svg path,
-.c0:focus svg path {
-  fill: #0066ff;
+  border: 1px solid #5ab2f2 !important;
+  box-shadow: 0px 0px 2px hsl(216,100%,50%);
+  outline: none;
 }
 
 .c0:hover {
   border: 1px solid #0066ff;
-  color: #0066ff;
 }
 
 .c0:disabled {
@@ -2029,6 +1960,7 @@ exports[`Button with size medium renders a primary variant with a label correctl
 .c0:hover,
 .c0:active,
 .c0:focus {
+  color: #ffffff;
   background-color: #003d99;
 }
 
@@ -2040,17 +1972,13 @@ exports[`Button with size medium renders a primary variant with a label correctl
 
 .c0:active,
 .c0:focus {
-  border: 1px solid #5ab2f2;
-}
-
-.c0:active svg path,
-.c0:focus svg path {
-  fill: #ffffff;
+  border: 1px solid #5ab2f2 !important;
+  box-shadow: 0px 0px 2px hsl(216,100%,50%);
+  outline: none;
 }
 
 .c0:hover {
   border: 1px solid #00000000;
-  color: #ffffff;
 }
 
 .c0:disabled {
@@ -2102,6 +2030,7 @@ exports[`Button with size medium renders a primary variant with a label correctl
 .c0:hover,
 .c0:active,
 .c0:focus {
+  color: #ffffff;
   background-color: #003d99;
 }
 
@@ -2113,17 +2042,13 @@ exports[`Button with size medium renders a primary variant with a label correctl
 
 .c0:active,
 .c0:focus {
-  border: 1px solid #5ab2f2;
-}
-
-.c0:active svg path,
-.c0:focus svg path {
-  fill: #ffffff;
+  border: 1px solid #5ab2f2 !important;
+  box-shadow: 0px 0px 2px hsl(216,100%,50%);
+  outline: none;
 }
 
 .c0:hover {
   border: 1px solid #00000000;
-  color: #ffffff;
 }
 
 .c0:disabled {
@@ -2182,28 +2107,25 @@ exports[`Button with size medium renders with a bare icon correctly 1`] = `
 .c0:hover,
 .c0:active,
 .c0:focus {
+  color: #003d99;
   background-color: #f2f2f2;
 }
 
 .c0:hover svg path,
 .c0:active svg path,
 .c0:focus svg path {
-  fill: #002966;
+  fill: #003d99;
 }
 
 .c0:active,
 .c0:focus {
-  border: 1px solid #5ab2f2;
-}
-
-.c0:active svg path,
-.c0:focus svg path {
-  fill: #b3b3b3;
+  border: 1px solid #5ab2f2 !important;
+  box-shadow: 0px 0px 2px hsl(216,100%,50%);
+  outline: none;
 }
 
 .c0:hover {
   border: 1px solid #00000000;
-  color: #003d99;
 }
 
 .c0:disabled {
@@ -2280,6 +2202,7 @@ exports[`Button with size medium renders with an icon correctly 1`] = `
 .c0:hover,
 .c0:active,
 .c0:focus {
+  color: #ffffff;
   background-color: #003d99;
 }
 
@@ -2291,17 +2214,13 @@ exports[`Button with size medium renders with an icon correctly 1`] = `
 
 .c0:active,
 .c0:focus {
-  border: 1px solid #5ab2f2;
-}
-
-.c0:active svg path,
-.c0:focus svg path {
-  fill: #ffffff;
+  border: 1px solid #5ab2f2 !important;
+  box-shadow: 0px 0px 2px hsl(216,100%,50%);
+  outline: none;
 }
 
 .c0:hover {
   border: 1px solid #00000000;
-  color: #ffffff;
 }
 
 .c0:disabled {
@@ -2371,28 +2290,25 @@ exports[`Button with size small renders a bare variant correctly 1`] = `
 .c0:hover,
 .c0:active,
 .c0:focus {
+  color: #003d99;
   background-color: #f2f2f2;
 }
 
 .c0:hover svg path,
 .c0:active svg path,
 .c0:focus svg path {
-  fill: #002966;
+  fill: #003d99;
 }
 
 .c0:active,
 .c0:focus {
-  border: 1px solid #5ab2f2;
-}
-
-.c0:active svg path,
-.c0:focus svg path {
-  fill: #b3b3b3;
+  border: 1px solid #5ab2f2 !important;
+  box-shadow: 0px 0px 2px hsl(216,100%,50%);
+  outline: none;
 }
 
 .c0:hover {
   border: 1px solid #00000000;
-  color: #003d99;
 }
 
 .c0:disabled {
@@ -2444,6 +2360,7 @@ exports[`Button with size small renders a ghost variant correctly 1`] = `
 .c0:hover,
 .c0:active,
 .c0:focus {
+  color: #0066ff;
   background-color: #ffffff;
 }
 
@@ -2455,17 +2372,13 @@ exports[`Button with size small renders a ghost variant correctly 1`] = `
 
 .c0:active,
 .c0:focus {
-  border: 1px solid #002966;
-}
-
-.c0:active svg path,
-.c0:focus svg path {
-  fill: #0066ff;
+  border: 1px solid #5ab2f2 !important;
+  box-shadow: 0px 0px 2px hsl(216,100%,50%);
+  outline: none;
 }
 
 .c0:hover {
   border: 1px solid #0066ff;
-  color: #0066ff;
 }
 
 .c0:disabled {
@@ -2517,6 +2430,7 @@ exports[`Button with size small renders a primary variant with a label correctly
 .c0:hover,
 .c0:active,
 .c0:focus {
+  color: #ffffff;
   background-color: #003d99;
 }
 
@@ -2528,17 +2442,13 @@ exports[`Button with size small renders a primary variant with a label correctly
 
 .c0:active,
 .c0:focus {
-  border: 1px solid #5ab2f2;
-}
-
-.c0:active svg path,
-.c0:focus svg path {
-  fill: #ffffff;
+  border: 1px solid #5ab2f2 !important;
+  box-shadow: 0px 0px 2px hsl(216,100%,50%);
+  outline: none;
 }
 
 .c0:hover {
   border: 1px solid #00000000;
-  color: #ffffff;
 }
 
 .c0:disabled {
@@ -2590,6 +2500,7 @@ exports[`Button with size small renders a primary variant with a label correctly
 .c0:hover,
 .c0:active,
 .c0:focus {
+  color: #ffffff;
   background-color: #003d99;
 }
 
@@ -2601,17 +2512,13 @@ exports[`Button with size small renders a primary variant with a label correctly
 
 .c0:active,
 .c0:focus {
-  border: 1px solid #5ab2f2;
-}
-
-.c0:active svg path,
-.c0:focus svg path {
-  fill: #ffffff;
+  border: 1px solid #5ab2f2 !important;
+  box-shadow: 0px 0px 2px hsl(216,100%,50%);
+  outline: none;
 }
 
 .c0:hover {
   border: 1px solid #00000000;
-  color: #ffffff;
 }
 
 .c0:disabled {
@@ -2670,28 +2577,25 @@ exports[`Button with size small renders with a bare icon correctly 1`] = `
 .c0:hover,
 .c0:active,
 .c0:focus {
+  color: #003d99;
   background-color: #f2f2f2;
 }
 
 .c0:hover svg path,
 .c0:active svg path,
 .c0:focus svg path {
-  fill: #002966;
+  fill: #003d99;
 }
 
 .c0:active,
 .c0:focus {
-  border: 1px solid #5ab2f2;
-}
-
-.c0:active svg path,
-.c0:focus svg path {
-  fill: #b3b3b3;
+  border: 1px solid #5ab2f2 !important;
+  box-shadow: 0px 0px 2px hsl(216,100%,50%);
+  outline: none;
 }
 
 .c0:hover {
   border: 1px solid #00000000;
-  color: #003d99;
 }
 
 .c0:disabled {
@@ -2768,6 +2672,7 @@ exports[`Button with size small renders with an icon correctly 1`] = `
 .c0:hover,
 .c0:active,
 .c0:focus {
+  color: #ffffff;
   background-color: #003d99;
 }
 
@@ -2779,17 +2684,13 @@ exports[`Button with size small renders with an icon correctly 1`] = `
 
 .c0:active,
 .c0:focus {
-  border: 1px solid #5ab2f2;
-}
-
-.c0:active svg path,
-.c0:focus svg path {
-  fill: #ffffff;
+  border: 1px solid #5ab2f2 !important;
+  box-shadow: 0px 0px 2px hsl(216,100%,50%);
+  outline: none;
 }
 
 .c0:hover {
   border: 1px solid #00000000;
-  color: #ffffff;
 }
 
 .c0:disabled {

--- a/src/components/Button/__tests__/__snapshots__/Button.test.tsx.snap
+++ b/src/components/Button/__tests__/__snapshots__/Button.test.tsx.snap
@@ -49,7 +49,7 @@ exports[`Button renders with a custom color theme correctly 1`] = `
 .c0:active,
 .c0:focus {
   border: 1px solid #5ab2f2 !important;
-  box-shadow: 0px 0px 2px hsl(216,100%,50%);
+  box-shadow: 0px 0px 2px #0066ff;
   outline: none;
 }
 
@@ -119,7 +119,7 @@ exports[`Button renders with a custom color theme correctly 2`] = `
 .c0:active,
 .c0:focus {
   border: 1px solid #5ab2f2 !important;
-  box-shadow: 0px 0px 2px hsl(216,100%,50%);
+  box-shadow: 0px 0px 2px #0066ff;
   outline: none;
 }
 
@@ -189,7 +189,7 @@ exports[`Button renders with a custom color theme correctly 3`] = `
 .c0:active,
 .c0:focus {
   border: 1px solid #5ab2f2 !important;
-  box-shadow: 0px 0px 2px hsl(216,100%,50%);
+  box-shadow: 0px 0px 2px #0066ff;
   outline: none;
 }
 
@@ -259,7 +259,7 @@ exports[`Button renders with a specified color preset correctly 1`] = `
 .c0:active,
 .c0:focus {
   border: 1px solid #5ab2f2 !important;
-  box-shadow: 0px 0px 2px hsl(216,100%,50%);
+  box-shadow: 0px 0px 2px #0066ff;
   outline: none;
 }
 
@@ -329,7 +329,7 @@ exports[`Button renders with a specified color preset correctly 2`] = `
 .c0:active,
 .c0:focus {
   border: 1px solid #5ab2f2 !important;
-  box-shadow: 0px 0px 2px hsl(216,100%,50%);
+  box-shadow: 0px 0px 2px #0066ff;
   outline: none;
 }
 
@@ -399,7 +399,7 @@ exports[`Button renders with a specified color preset correctly 3`] = `
 .c0:active,
 .c0:focus {
   border: 1px solid #5ab2f2 !important;
-  box-shadow: 0px 0px 2px hsl(216,100%,50%);
+  box-shadow: 0px 0px 2px #0066ff;
   outline: none;
 }
 
@@ -469,7 +469,7 @@ exports[`Button renders with inset correctly 1`] = `
 .c0:active,
 .c0:focus {
   border: 1px solid #5ab2f2 !important;
-  box-shadow: 0px 0px 2px hsl(216,100%,50%);
+  box-shadow: 0px 0px 2px #0066ff;
   outline: none;
 }
 
@@ -558,7 +558,7 @@ exports[`Button renders with inset correctly 2`] = `
 .c0:active,
 .c0:focus {
   border: 1px solid #5ab2f2 !important;
-  box-shadow: 0px 0px 2px hsl(216,100%,50%);
+  box-shadow: 0px 0px 2px #0066ff;
   outline: none;
 }
 
@@ -647,7 +647,7 @@ exports[`Button renders with inset correctly 3`] = `
 .c0:active,
 .c0:focus {
   border: 1px solid #5ab2f2 !important;
-  box-shadow: 0px 0px 2px hsl(216,100%,50%);
+  box-shadow: 0px 0px 2px #0066ff;
   outline: none;
 }
 
@@ -743,7 +743,7 @@ exports[`Button renders with text and an icon correctly 1`] = `
 .c0:active,
 .c0:focus {
   border: 1px solid #5ab2f2 !important;
-  box-shadow: 0px 0px 2px hsl(216,100%,50%);
+  box-shadow: 0px 0px 2px #0066ff;
   outline: none;
 }
 
@@ -838,7 +838,7 @@ exports[`Button renders with text and an icon correctly 2`] = `
 .c0:active,
 .c0:focus {
   border: 1px solid #5ab2f2 !important;
-  box-shadow: 0px 0px 2px hsl(216,100%,50%);
+  box-shadow: 0px 0px 2px #0066ff;
   outline: none;
 }
 
@@ -933,7 +933,7 @@ exports[`Button renders with text and an icon correctly 3`] = `
 .c0:active,
 .c0:focus {
   border: 1px solid #5ab2f2 !important;
-  box-shadow: 0px 0px 2px hsl(216,100%,50%);
+  box-shadow: 0px 0px 2px #0066ff;
   outline: none;
 }
 
@@ -1028,7 +1028,7 @@ exports[`Button renders with text, icon and inset correctly 1`] = `
 .c0:active,
 .c0:focus {
   border: 1px solid #5ab2f2 !important;
-  box-shadow: 0px 0px 2px hsl(216,100%,50%);
+  box-shadow: 0px 0px 2px #0066ff;
   outline: none;
 }
 
@@ -1142,7 +1142,7 @@ exports[`Button renders with text, icon and inset correctly 2`] = `
 .c0:active,
 .c0:focus {
   border: 1px solid #5ab2f2 !important;
-  box-shadow: 0px 0px 2px hsl(216,100%,50%);
+  box-shadow: 0px 0px 2px #0066ff;
   outline: none;
 }
 
@@ -1256,7 +1256,7 @@ exports[`Button renders with text, icon and inset correctly 3`] = `
 .c0:active,
 .c0:focus {
   border: 1px solid #5ab2f2 !important;
-  box-shadow: 0px 0px 2px hsl(216,100%,50%);
+  box-shadow: 0px 0px 2px #0066ff;
   outline: none;
 }
 
@@ -1363,7 +1363,7 @@ exports[`Button with size large renders a bare variant correctly 1`] = `
 .c0:active,
 .c0:focus {
   border: 1px solid #5ab2f2 !important;
-  box-shadow: 0px 0px 2px hsl(216,100%,50%);
+  box-shadow: 0px 0px 2px #0066ff;
   outline: none;
 }
 
@@ -1433,7 +1433,7 @@ exports[`Button with size large renders a ghost variant correctly 1`] = `
 .c0:active,
 .c0:focus {
   border: 1px solid #5ab2f2 !important;
-  box-shadow: 0px 0px 2px hsl(216,100%,50%);
+  box-shadow: 0px 0px 2px #0066ff;
   outline: none;
 }
 
@@ -1503,7 +1503,7 @@ exports[`Button with size large renders a primary variant with a label correctly
 .c0:active,
 .c0:focus {
   border: 1px solid #5ab2f2 !important;
-  box-shadow: 0px 0px 2px hsl(216,100%,50%);
+  box-shadow: 0px 0px 2px #0066ff;
   outline: none;
 }
 
@@ -1573,7 +1573,7 @@ exports[`Button with size large renders a primary variant with a label correctly
 .c0:active,
 .c0:focus {
   border: 1px solid #5ab2f2 !important;
-  box-shadow: 0px 0px 2px hsl(216,100%,50%);
+  box-shadow: 0px 0px 2px #0066ff;
   outline: none;
 }
 
@@ -1650,7 +1650,7 @@ exports[`Button with size large renders with a bare icon correctly 1`] = `
 .c0:active,
 .c0:focus {
   border: 1px solid #5ab2f2 !important;
-  box-shadow: 0px 0px 2px hsl(216,100%,50%);
+  box-shadow: 0px 0px 2px #0066ff;
   outline: none;
 }
 
@@ -1745,7 +1745,7 @@ exports[`Button with size large renders with an icon correctly 1`] = `
 .c0:active,
 .c0:focus {
   border: 1px solid #5ab2f2 !important;
-  box-shadow: 0px 0px 2px hsl(216,100%,50%);
+  box-shadow: 0px 0px 2px #0066ff;
   outline: none;
 }
 
@@ -1833,7 +1833,7 @@ exports[`Button with size medium renders a bare variant correctly 1`] = `
 .c0:active,
 .c0:focus {
   border: 1px solid #5ab2f2 !important;
-  box-shadow: 0px 0px 2px hsl(216,100%,50%);
+  box-shadow: 0px 0px 2px #0066ff;
   outline: none;
 }
 
@@ -1903,7 +1903,7 @@ exports[`Button with size medium renders a ghost variant correctly 1`] = `
 .c0:active,
 .c0:focus {
   border: 1px solid #5ab2f2 !important;
-  box-shadow: 0px 0px 2px hsl(216,100%,50%);
+  box-shadow: 0px 0px 2px #0066ff;
   outline: none;
 }
 
@@ -1973,7 +1973,7 @@ exports[`Button with size medium renders a primary variant with a label correctl
 .c0:active,
 .c0:focus {
   border: 1px solid #5ab2f2 !important;
-  box-shadow: 0px 0px 2px hsl(216,100%,50%);
+  box-shadow: 0px 0px 2px #0066ff;
   outline: none;
 }
 
@@ -2043,7 +2043,7 @@ exports[`Button with size medium renders a primary variant with a label correctl
 .c0:active,
 .c0:focus {
   border: 1px solid #5ab2f2 !important;
-  box-shadow: 0px 0px 2px hsl(216,100%,50%);
+  box-shadow: 0px 0px 2px #0066ff;
   outline: none;
 }
 
@@ -2120,7 +2120,7 @@ exports[`Button with size medium renders with a bare icon correctly 1`] = `
 .c0:active,
 .c0:focus {
   border: 1px solid #5ab2f2 !important;
-  box-shadow: 0px 0px 2px hsl(216,100%,50%);
+  box-shadow: 0px 0px 2px #0066ff;
   outline: none;
 }
 
@@ -2215,7 +2215,7 @@ exports[`Button with size medium renders with an icon correctly 1`] = `
 .c0:active,
 .c0:focus {
   border: 1px solid #5ab2f2 !important;
-  box-shadow: 0px 0px 2px hsl(216,100%,50%);
+  box-shadow: 0px 0px 2px #0066ff;
   outline: none;
 }
 
@@ -2303,7 +2303,7 @@ exports[`Button with size small renders a bare variant correctly 1`] = `
 .c0:active,
 .c0:focus {
   border: 1px solid #5ab2f2 !important;
-  box-shadow: 0px 0px 2px hsl(216,100%,50%);
+  box-shadow: 0px 0px 2px #0066ff;
   outline: none;
 }
 
@@ -2373,7 +2373,7 @@ exports[`Button with size small renders a ghost variant correctly 1`] = `
 .c0:active,
 .c0:focus {
   border: 1px solid #5ab2f2 !important;
-  box-shadow: 0px 0px 2px hsl(216,100%,50%);
+  box-shadow: 0px 0px 2px #0066ff;
   outline: none;
 }
 
@@ -2443,7 +2443,7 @@ exports[`Button with size small renders a primary variant with a label correctly
 .c0:active,
 .c0:focus {
   border: 1px solid #5ab2f2 !important;
-  box-shadow: 0px 0px 2px hsl(216,100%,50%);
+  box-shadow: 0px 0px 2px #0066ff;
   outline: none;
 }
 
@@ -2513,7 +2513,7 @@ exports[`Button with size small renders a primary variant with a label correctly
 .c0:active,
 .c0:focus {
   border: 1px solid #5ab2f2 !important;
-  box-shadow: 0px 0px 2px hsl(216,100%,50%);
+  box-shadow: 0px 0px 2px #0066ff;
   outline: none;
 }
 
@@ -2590,7 +2590,7 @@ exports[`Button with size small renders with a bare icon correctly 1`] = `
 .c0:active,
 .c0:focus {
   border: 1px solid #5ab2f2 !important;
-  box-shadow: 0px 0px 2px hsl(216,100%,50%);
+  box-shadow: 0px 0px 2px #0066ff;
   outline: none;
 }
 
@@ -2685,7 +2685,7 @@ exports[`Button with size small renders with an icon correctly 1`] = `
 .c0:active,
 .c0:focus {
   border: 1px solid #5ab2f2 !important;
-  box-shadow: 0px 0px 2px hsl(216,100%,50%);
+  box-shadow: 0px 0px 2px #0066ff;
   outline: none;
 }
 

--- a/src/components/Button/components/ButtonBase.tsx
+++ b/src/components/Button/components/ButtonBase.tsx
@@ -199,6 +199,11 @@ const getIconMargin = (props: IStyledBaseButton) => {
   return icon && label ? (size === "small" ? "0.2rem" : "0.4rem") : "0rem"
 }
 
+const getBoxShadow = (props: IStyledBaseButton) => {
+  const { theme: { knitui } } = props
+  return `0px 0px 2px ${knitui.shades.blue50}`
+}
+
 const StyledButton = styled.button<IStyledBaseButton>`
   display: flex;
   align-items: center;
@@ -232,7 +237,7 @@ const StyledButton = styled.button<IStyledBaseButton>`
   :active,
   :focus {
     border: ${props => getBorder("active", props)} !important;
-    box-shadow: 0px 0px 2px hsl(216, 100%, 50%);
+    box-shadow: ${props => getBoxShadow(props)};
     outline: none;
   }
   :hover {

--- a/src/components/Button/components/ButtonBase.tsx
+++ b/src/components/Button/components/ButtonBase.tsx
@@ -136,6 +136,8 @@ const getFontColor = (state: ButtonState, props: IStyledBaseButton) => {
       }
       return baseFontColor
     case "hover":
+    case "active":
+    case "focus":
       if (bare) {
         return getHoverBackgroundColor(props)
       }
@@ -166,29 +168,6 @@ const getBackgroundColor = (state: ButtonState, props: IStyledBaseButton) => {
     : getHoverBackgroundColor(props)
 }
 
-const getIconColor = (state: ButtonState, props: IStyledBaseButton) => {
-  const {
-    customProps: { bare, ghost },
-  } = props
-  if (!bare) {
-    switch(state) {
-      case "hover":
-      case "active":
-      case "focus":
-        return ghost ? getHoverFontColor(props) : getBaseFontColor(props)
-      default:
-        return getBaseFontColor(props)
-    }
-  }
-  switch (state) {
-    case "focus":
-    case "active":
-      return getHoverFontColor(props)
-    case "default":
-    default:
-      return getFontColor("default", props)
-  }
-}
 
 const getBorder = (state: ButtonState, props: IStyledBaseButton) => {
   const {
@@ -199,7 +178,7 @@ const getBorder = (state: ButtonState, props: IStyledBaseButton) => {
   switch (state) {
     case "active":
     case "focus":
-      borderColor = ghost ? getBaseFontColor(props) : getHighlighColor(props)
+      borderColor = getHighlighColor(props)
       break
     case "hover":
       borderColor = ghost
@@ -238,27 +217,26 @@ const StyledButton = styled.button<IStyledBaseButton>`
   span {
     margin-right: ${props => getIconMargin(props)};
     svg path {
-      fill: ${props => getIconColor("default", props)};
+      fill: ${props => getFontColor("default", props)};
     }
   }
   :hover,
   :active,
   :focus {
+    color: ${props => getFontColor("hover", props)};
     background-color: ${props => getBackgroundColor("hover", props)};
     svg path {
-      fill: ${props => getIconColor("hover", props)};
+      fill: ${props => getFontColor("hover", props)};
     }
   }
   :active,
   :focus {
-    border: ${props => getBorder("active", props)};
-    svg path {
-      fill: ${props => getIconColor("focus", props)};
-    }
+    border: ${props => getBorder("active", props)} !important;
+    box-shadow: 0px 0px 2px hsl(216, 100%, 50%);
+    outline: none;
   }
   :hover {
     border: ${props => getBorder("hover", props)};
-    color: ${props => getFontColor("hover", props)};
   }
   :disabled {
     opacity: 0.5;


### PR DESCRIPTION
## Description

* Removes the function to compute the icon color, and replaces it with the one that computes font color (font color is always equal to icon color, difference was introduced due to some inconsistency in the design specs)
* Remove the default outline from the button in the focus state.
* The styles in the focus and active states are now always same.
* Adds the missing `box-shadow` property.