### PR TITLE
Icon: Modified size api

### DIFF
--- a/src/components/Breadcrumb/Breadcrumb.stories.tsx
+++ b/src/components/Breadcrumb/Breadcrumb.stories.tsx
@@ -92,7 +92,7 @@ stories
     <Breadcrumb>
       <Breadcrumb.Item>Dashboard</Breadcrumb.Item>
       <Breadcrumb.Item>
-        <Icon height="18px" width="18px" type={text("Icon", "oAddCircle")} />
+        <Icon size="18px" type={text("Icon", "oAddCircle")} />
         Reports
       </Breadcrumb.Item>
       <Breadcrumb.Item>

--- a/src/components/Breadcrumb/__tests__/Breadcrumb.test.tsx
+++ b/src/components/Breadcrumb/__tests__/Breadcrumb.test.tsx
@@ -110,7 +110,7 @@ describe("Breadcrumb", () => {
         <Breadcrumb>
           <Breadcrumb.Item>Dashboard</Breadcrumb.Item>
           <Breadcrumb.Item>
-            <Icon height="18px" width="18px" type="oAddCircle" />
+            <Icon size="18px" type="oAddCircle" />
             Reports
           </Breadcrumb.Item>
           <Breadcrumb.Item>

--- a/src/components/Icon/Icon.stories.tsx
+++ b/src/components/Icon/Icon.stories.tsx
@@ -12,8 +12,11 @@ const colors = ["#000000", "#990000", "#036600"]
 const allIcons = Object.values(Icons)
 
 stories
-  .add("Basic Icon", () => <Icon type="oAddCircle" />)
-  .add("Icon with color", () => <Icon type="oAddCircle" fill="red" />)
+  .add("Icon", () => {
+    const size = select("Size", sizes, "18px")
+    const color = select("Color", colors, "#000000")
+    return <Icon type="oAddCircle" size={size} fill={color} />
+  })
   .add("All icons", () => {
     const size = select("Size", sizes, "18px")
     const color = select("Color", colors, "#000000")

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -5,13 +5,18 @@ import { withProps } from "../../common/_utils"
 
 export interface IIconProps {
   type: string
-  height?: string
-  width?: string
+  size?: { width: string; height: string } | string
   fill?: string
   customStyles?: string
 }
 
-const StyledIconWrapper: any = withProps<IIconProps>()(styled.span)`
+interface IIconWrapper {
+  width: string
+  height: string
+  customStyles?: string
+}
+
+const StyledIconWrapper: any = withProps<IIconWrapper>()(styled.span)`
   cursor: inherit;
   display: inline-block;
   height: ${({ height }) => height};
@@ -22,14 +27,18 @@ const StyledIconWrapper: any = withProps<IIconProps>()(styled.span)`
 `
 
 const Icon: any = (props: IIconProps) => {
-  const {
-    type,
-    height = "18px",
-    width = "18px",
-    fill = "#000",
-    customStyles = "",
-  } = props
-  const svgStyles = { height, width, fill }
+  const { type, size, fill = "#000", customStyles = "" } = props
+  let width = "18px",
+    height = "18px"
+  if (typeof size === "string") {
+    width = size
+    height = size
+  } else if (typeof size === "object") {
+    width = size.width
+    height = size.height
+  }
+
+  const svgStyles = { width, height, fill }
   // If type is not provided, then "oCheckBoxOutlineBlank" is used as placeholder icon
   const defaultType = "oCheckBoxOutlineBlank"
   const icon =


### PR DESCRIPTION
Moving away from supplying both width and height props separately to each icon, introducing `size` prop of type - 
```
size: string | {width: string, height: string}
```
