### PR TITLE
Add font color override api in label

### DIFF
--- a/src/components/Label/Label.stories.tsx
+++ b/src/components/Label/Label.stories.tsx
@@ -57,6 +57,18 @@ stories
       focus={boolean("Focus", false)}
     />
   ))
+  .add("with a custom font color", () => (
+    <Label
+      text={text("text", "Label")}
+      expanded={boolean("Expanded", false)}
+      size={select("Size", sizeOptions, "medium")}
+      colorPreset={select("Color preset", colorThemeOptions, "neutral")}
+      customFontColor={text("Custom font color", "#F7B3B3")}
+      rounded={boolean("Rounded", false)}
+      outlined={boolean("Outlined", false)}
+      focus={boolean("Focus", false)}
+    />
+  ))
   .add("Rounded", () => (
     <Label
       text={text("text", "Label")}

--- a/src/components/Label/Label.tsx
+++ b/src/components/Label/Label.tsx
@@ -45,7 +45,10 @@ const parseColorTheme = (props: IStyledLabel) => {
 }
 const getBackgroundColor = (props: IStyledLabel) => parseColorTheme(props).background
 
-const getFontColor = (props: IStyledLabel) => parseColorTheme(props).font
+const getFontColor = (props: IStyledLabel) => {
+  const { customProps: { customFontColor } } = props
+  return customFontColor || parseColorTheme(props).font
+}
 
 const getDarkenedBorderColor = (props: IStyledLabel) =>
   getBackgroundColor(props).set("hsl.l", "-0.2")

--- a/src/components/Label/README.md
+++ b/src/components/Label/README.md
@@ -26,6 +26,7 @@ import { Label } from "KnitUI"
 | className | string | Yes | None | CSS class name to be added |
 | style | CSS Object | Yes | None | CSS style to be added |
 | insetColor | string | Yes | None | If provided, will add a small decoration on the label with the given color. Also the background is set to a default which can be changed by `customColor` but not through the `colorPreset` |
+| customFontColor | string | Yes | None | Overrides the default font colors |
 
 ## Inline Label
 
@@ -49,3 +50,4 @@ import { Label } from "KnitUI"
 | className | string | Yes | None | CSS class name to be added |
 | style | CSS Object | Yes | None | CSS style to be added |
 | insetColor | string | Yes | None | If provided, will add a small decoration on the label with the given color. Also the background is set to a default which can be changed by `customColor` but not through the `colorPreset` |
+| customFontColor | string | Yes | None | Overrides the default font colors |

--- a/src/components/Label/__tests__/Label.test.tsx
+++ b/src/components/Label/__tests__/Label.test.tsx
@@ -113,6 +113,15 @@ describe("Label", () => {
     expect(asFragment()).toMatchSnapshot()
   })
 
+  it("custom font color", () => {
+    const { asFragment } = render(
+      <ThemeProvider>
+        <Label text="label" customFontColor="#F7B3B3" />
+      </ThemeProvider>
+    )
+    expect(asFragment()).toMatchSnapshot()
+  })
+
   it("inset", () => {
     const { asFragment } = render(
       <ThemeProvider>

--- a/src/components/Label/__tests__/__snapshots__/Label.test.tsx.snap
+++ b/src/components/Label/__tests__/__snapshots__/Label.test.tsx.snap
@@ -33,6 +33,39 @@ exports[`Label custom class 1`] = `
 </DocumentFragment>
 `;
 
+exports[`Label custom font color 1`] = `
+<DocumentFragment>
+  .c0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  padding: 0.2rem 0.7rem 0.2rem 0.7rem;
+  background-color: #002966;
+  color: #F7B3B3;
+  font-size: 1.4rem;
+  line-height: 2rem;
+  border-radius: 0.2rem;
+  border: 1px solid transparent;
+  box-sizing: border-box;
+  box-shadow: none;
+  overflow: hidden;
+}
+
+<div
+    class="c0"
+  >
+    <span>
+      label
+    </span>
+  </div>
+</DocumentFragment>
+`;
+
 exports[`Label custom style 1`] = `
 <DocumentFragment>
   .c0 {

--- a/src/components/Label/types.ts
+++ b/src/components/Label/types.ts
@@ -18,6 +18,8 @@ export interface BaseLabelProps extends BaseComponentProps {
   colorPreset?: ColorPreset
   /** Custom color to override presets */
   customColor?: CustomColor
+  /** Override the default font colors */
+  customFontColor?: CustomColor 
 }
 
 export interface InlineLabelProps extends BaseLabelProps {


### PR DESCRIPTION
## Description

This is useful for supporting several use cases where the font color is not black or white.