### PR TITLE
Add prop theme to ThemeProvider

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -6,7 +6,7 @@ import theme from "./theme"
 import { GlobalStyles, ThemeProvider } from "../src/common/styles"
 
 // automatically import all files ending in *.stories.tsx
-const req = require.context("../src/components", true, /.stories.tsx$/)
+const req = require.context("../src/", true, /.stories.tsx$/)
 
 const ThemeProviderDecorator = storyFn => (
   <ThemeProvider>{storyFn()}</ThemeProvider>

--- a/src/common/_utils/__tests__/utils.test.ts
+++ b/src/common/_utils/__tests__/utils.test.ts
@@ -1,41 +1,43 @@
 import { getFontColor, parseColorPreset, parseCustomColor } from "../index"
-import { chromaPalette } from "../../styles/variables"
+import { palette, generateTheme } from "../../../"
+const { knitui: theme } = generateTheme(palette)
+const chromaPalette = theme.chromaPalette
 const { Neutral0, Neutral90 } = chromaPalette
 
 describe("_utils", () => {
   describe("getFontColor", () => {
     it("font is white for black background", () => {
-      const fontColor = getFontColor(chromaPalette.Neutral90)
+      const fontColor = getFontColor(theme, chromaPalette.Neutral90)
       expect(fontColor.toString()).toBe(Neutral0.toString())
     })
 
     it("font is black for white background", () => {
-      const fontColor = getFontColor(chromaPalette.Neutral0)
+      const fontColor = getFontColor(theme, chromaPalette.Neutral0)
       expect(fontColor.toString()).toBe(Neutral90.toString())
     })
 
     it("font is white for neutral background", () => {
-      const fontColor = getFontColor(chromaPalette.Blue100)
+      const fontColor = getFontColor(theme, chromaPalette.Blue100)
       expect(fontColor.toString()).toBe(Neutral0.toString())
     })
 
     it("font is white for success background", () => {
-      const fontColor = getFontColor(chromaPalette.Neutral90)
+      const fontColor = getFontColor(theme, chromaPalette.Neutral90)
       expect(fontColor.toString()).toBe(Neutral0.toString())
     })
 
     it("font is white for error background", () => {
-      const fontColor = getFontColor(chromaPalette.Green80)
+      const fontColor = getFontColor(theme, chromaPalette.Green80)
       expect(fontColor.toString()).toBe(Neutral0.toString())
     })
 
     it("font is white for unsaved background", () => {
-      const fontColor = getFontColor(chromaPalette.Magenta80)
+      const fontColor = getFontColor(theme, chromaPalette.Magenta80)
       expect(fontColor.toString()).toBe(Neutral0.toString())
     })
 
     it("font is black for warning background", () => {
-      const fontColor = getFontColor(chromaPalette.Yellow80)
+      const fontColor = getFontColor(theme, chromaPalette.Yellow80)
       expect(fontColor.toString()).toBe(Neutral90.toString())
     })
   })
@@ -44,7 +46,7 @@ describe("_utils", () => {
     it("should return an object with parsed colors", () => {
       const backgroundColor = "#000000"
       const fontColor = "#ffffff"
-      const parsed = parseCustomColor(backgroundColor)
+      const parsed = parseCustomColor(theme, backgroundColor)
       expect(parsed.background.toString()).toBe(backgroundColor)
       expect(parsed.font.toString()).toBe(fontColor)
     })
@@ -52,7 +54,7 @@ describe("_utils", () => {
 
   describe("parseColorPreset", () => {
     it("should return an object with parsed colors", () => {
-      const parsed = parseColorPreset("neutral")
+      const parsed = parseColorPreset(theme, "neutral")
       expect(parsed.background.toString()).toBe("#002966")
       expect(parsed.font.toString()).toBe("#ffffff")
     })

--- a/src/common/_utils/index.ts
+++ b/src/common/_utils/index.ts
@@ -1,8 +1,6 @@
 import { ThemedStyledFunction } from "styled-components"
 import chroma from "chroma-js"
 import { ColorPreset, CustomColor } from "../types"
-import * as theme from "../styles/variables"
-const { secondaryPalette, chromaPalette } = theme
 
 export const insertIf = (
   obj: any = {},
@@ -42,15 +40,15 @@ export const isLightColor = color => color.get("hsl.l") >= 0.5
 /**
  * Determines the appropriate font color based on the background color.
  */
-export const getFontColor = backGroundColor => {
+export const getFontColor = (theme, backGroundColor) => {
   return isLightColor(backGroundColor)
-    ? chromaPalette.Neutral90
-    : chromaPalette.Neutral0
+    ? theme.chromaPalette.Neutral90
+    : theme.chromaPalette.Neutral0
 }
 
-const createParsedColorTheme = backgroundColor => ({
+const createParsedColorTheme = (theme, backgroundColor) => ({
   background: backgroundColor,
-  font: getFontColor(backgroundColor),
+  font: getFontColor(theme, backgroundColor),
 })
 
 /**
@@ -58,7 +56,7 @@ const createParsedColorTheme = backgroundColor => ({
  * with appropriate chroma colors.
  * @param backGroundColor A plain CSS color string
  */
-export const parseCustomColor = (customColor: CustomColor) => {
+export const parseCustomColor = (theme, customColor: CustomColor) => {
   if (
     !(
       chroma.valid(customColor) ||
@@ -76,7 +74,7 @@ export const parseCustomColor = (customColor: CustomColor) => {
     }
   }
   customColor = chroma(customColor)
-  return createParsedColorTheme(customColor)
+  return createParsedColorTheme(theme, customColor)
 }
 
 /**
@@ -84,7 +82,7 @@ export const parseCustomColor = (customColor: CustomColor) => {
  * with appropriate chroma colors.
  * @param backGroundColor One of the predefined preset values
  */
-export const parseColorPreset = (backgroundColor: ColorPreset) => {
-  backgroundColor = secondaryPalette[backgroundColor]
-  return createParsedColorTheme(backgroundColor)
+export const parseColorPreset = (theme, backgroundColor: ColorPreset) => {
+  backgroundColor = theme.secondaryPalette[backgroundColor]
+  return createParsedColorTheme(theme, backgroundColor)
 }

--- a/src/common/styles/ThemeProvider.stories.tsx
+++ b/src/common/styles/ThemeProvider.stories.tsx
@@ -1,0 +1,24 @@
+import React from "react"
+import { storiesOf } from "@storybook/react"
+import ThemeProvider from "./ThemeProvider"
+import * as palette from "./palette"
+import { Button } from "../../"
+import generateTheme from "./variables"
+
+const stories = storiesOf("ThemeProvider", module)
+
+stories.add("Blue100 overright to #1182D4", () => {
+  let newPalette = {
+    ...palette,
+    Blue100: {
+      hsl: [205, 85, 45],
+      hex: "#1182D4",
+    },
+  }
+  let theme = generateTheme(newPalette)
+  return (
+    <ThemeProvider theme={theme}>
+      <Button type="secondary" size="small" label="Changed Color of Neutral" />
+    </ThemeProvider>
+  )
+})

--- a/src/common/styles/ThemeProvider.tsx
+++ b/src/common/styles/ThemeProvider.tsx
@@ -1,9 +1,9 @@
 import React from "react"
 import { ThemeProvider as Theme } from "styled-components"
-import * as theme from "./variables"
+import { palette as defaultPalette, generateTheme } from "./"
 
-const ThemeProvider = ({ children }) => {
-  return <Theme theme={{knitui: theme}}>{children}</Theme>
-}
+const ThemeProvider = ({ children, theme = generateTheme(defaultPalette) }) => (
+  <Theme theme={theme}>{children}</Theme>
+)
 
 export default ThemeProvider

--- a/src/common/styles/__test__/ThemeProvider.test.tsx
+++ b/src/common/styles/__test__/ThemeProvider.test.tsx
@@ -1,0 +1,28 @@
+import React from "react"
+import * as palette from "../palette"
+import generateTheme from "../variables"
+import { render } from "react-testing-library"
+import ThemeProvider from "../ThemeProvider"
+import { Button } from "../../.."
+
+describe("Passing Custom Theme", () => {
+  // Changing one of the palette color
+  let newPalette = {
+    ...palette,
+    Blue100: {
+      hsl: [205, 85, 45],
+      hex: "#1182D4",
+    },
+  }
+
+  const knituiTheme = generateTheme(newPalette)
+
+  it("Changing palette color Blue100 to #1182D4", () => {
+    const { asFragment } = render(
+      <ThemeProvider theme={knituiTheme}>
+        <Button type="primary" size="small" label="Changed Color of Neutral" />
+      </ThemeProvider>
+    )
+    expect(asFragment()).toMatchSnapshot()
+  })
+})

--- a/src/common/styles/__test__/__snapshots__/ThemeProvider.test.tsx.snap
+++ b/src/common/styles/__test__/__snapshots__/ThemeProvider.test.tsx.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Passing Custom Theme Changing palette color Blue100 to #1182D4 1`] = `
+<DocumentFragment>
+  <button
+    class="sc-bwzfXH iRfXCP"
+  >
+    Changed Color of Neutral
+  </button>
+</DocumentFragment>
+`;

--- a/src/common/styles/index.tsx
+++ b/src/common/styles/index.tsx
@@ -1,2 +1,5 @@
 export { default as GlobalStyles } from "./GlobalStyles"
 export { default as ThemeProvider } from "./ThemeProvider"
+import * as palette from "./palette"
+export { palette }
+export { default as generateTheme } from "./variables"

--- a/src/common/styles/variables.tsx
+++ b/src/common/styles/variables.tsx
@@ -1,55 +1,7 @@
 import chroma from "chroma-js"
-import * as palette from "./palette"
 
 // Helpers
 const multiply = (a: number, b: number) => a * b
-
-const baseUnit = 10
-export const base = `${baseUnit}px`
-export const baseIncrementUnit = 0.2
-
-// Unit measurements (measurements relative to base unit i.e 10px)
-export const unit12 = 1.2
-export const unit14 = 1.4
-export const unit16 = 1.6
-export const unit18 = 1.8
-
-// Font size and line height associations
-export const typography = {
-  10: {
-    fontSize: 1.0,
-    lineHeight: 1.6,
-  },
-  12: {
-    fontSize: 1.2,
-    lineHeight: 1.8,
-  },
-  14: {
-    fontSize: 1.4,
-    lineHeight: 2.0,
-  },
-  16: {
-    fontSize: 1.6,
-    lineHeight: 2.0,
-  },
-  18: {
-    fontSize: 1.8,
-    lineHeight: 2.4,
-  },
-  20: {
-    fontSize: 2.0,
-    lineHeight: 2.8,
-  },
-}
-
-// Type
-export const fontFamily =
-  "InterRegular, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol"
-export const fontSize12 = "1.2rem"
-export const fontSize14 = "1.4rem" // for Paragraphs
-export const fontSize16 = "1.6rem" // for Leads
-export const fontSize18 = "1.8rem" // for Headings
-export const fontSize20 = "2rem"
 
 // Colors
 
@@ -61,106 +13,180 @@ const hslToChroma = (hsl: Array<number>) => {
   const [h, s, l] = hsl
   return chroma.hsl(h, s / 100, l / 100)
 }
+const baseUnit = 10
 
 /**
- * Create a new palette by parsing the corresponding color values
- * into chroma objects.
+ * The generateTheme function is exposed to user so that palette can have
+ * additional color, also palette is exposed to user so he can get
+ * existing colors
  */
-export const chromaPalette = Object.entries(palette)
-  .map(([colorName, values]) => ({
-    [colorName]: hslToChroma(values.hsl),
-  }))
-  .reduce((acc, cur) => ({ ...acc, ...cur }), {})
+const generateTheme = palette => {
+  /**
+   * Create a new palette by parsing the corresponding color values
+   * into chroma objects.
+   */
+  let chromaPalette = Object.entries(palette)
+    .map(([colorName, values]: [string, any]) => ({
+      [colorName]: hslToChroma(values.hsl),
+    }))
+    .reduce((acc, cur) => ({ ...acc, ...cur }), {})
 
-export const primaryHues = {
-  default: "#293979",
+  /** Default Theme --> */
+  /**
+   * The defualt theme object is created every time so that theme is not
+   * get overlaped, as Modules do immutable export
+   */
+  let defaultTheme: any = {
+    baseUnit: 10,
+    base: `${baseUnit}px`,
+    baseIncrementUnit: 0.2,
+
+    // Unit measurements (measurements relative to base unit i.e 10px)
+    unit12: 1.2,
+    unit14: 1.4,
+    unit16: 1.6,
+    unit18: 1.8,
+
+    // Font size and line height associations
+    typography: {
+      10: {
+        fontSize: 1.0,
+        lineHeight: 1.6,
+      },
+      12: {
+        fontSize: 1.2,
+        lineHeight: 1.8,
+      },
+      14: {
+        fontSize: 1.4,
+        lineHeight: 2.0,
+      },
+      16: {
+        fontSize: 1.6,
+        lineHeight: 2.0,
+      },
+      18: {
+        fontSize: 1.8,
+        lineHeight: 2.4,
+      },
+      20: {
+        fontSize: 2.0,
+        lineHeight: 2.8,
+      },
+    },
+
+    // Type
+    fontFamily:
+      "InterRegular, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
+    fontSize12: "1.2rem",
+    fontSize14: "1.4rem", // for Paragraphs
+    fontSize16: "1.6rem", // for Leads
+    fontSize18: "1.8rem", // for Headings
+    fontSize20: "2rem",
+
+    primaryHues: {
+      default: "#293979",
+    },
+
+    // TODO: This mapping should be defined by UX
+    secondaryPalette: {
+      neutral: chromaPalette.Blue100,
+      danger: chromaPalette.Crimson80,
+      success: chromaPalette.Green80,
+      warning: chromaPalette.Yellow80,
+      unsaved: chromaPalette.Magenta80,
+    },
+
+    // TODO: Remove this and its references and use chromaPallete directly
+    shades: {
+      // Shades of gray
+      white: chromaPalette.Neutral0,
+      gray95: chromaPalette.Neutral10,
+      gray90: chromaPalette.Neutral20,
+      gray85: chromaPalette.Neutral30,
+      gray50: chromaPalette.Neutral50,
+      gray20: chromaPalette.Neutral80,
+      black: chromaPalette.Neutral90,
+      transparent: chroma.hsl(0, 0, 0, 0),
+
+      // Shades of blue
+      lightBlue: chromaPalette.Azure80,
+      blue40: chroma.hsl(205, 0.85, 0.4),
+      blue50: chroma.hsl(216, 1, 0.5),
+    },
+
+    // Properties
+    lineHeight: "2rem",
+    borderRadius: `${multiply(0.4, baseUnit)}px`,
+    defaultPadding: `${multiply(0.4, baseUnit)}px ${baseUnit}px`,
+    defaultTextPadding: "1.4rem",
+
+    // input
+    inputFocusOutline: "none",
+    inputBgDefault: "hsl(0, 0%, 95%)",
+    inputColor: "hsl(0, 0%, 5%)",
+    inputPlaceholderColor: "hsl(0, 0%, 60%)",
+    inputPlaceholderColorActive: "hsl(0, 0%, 80%)",
+    inputBgHover: "hsl(0, 0%, 90%)",
+    inputBgActive: "hsl(0, 0%, 100%)",
+    inputBgFocus: "hsl(0,0%,100%)",
+    inputBgDisabled: "hsl(0, 0%, 50%)",
+    inputBorderRadius: "4px",
+    inputBorderColor: "transparent",
+    inputFocusBorderColor: chromaPalette.Azure80,
+    inputError: "#990000",
+    inputSuccess: "#05b300",
+    inputFocusBoxShadow: "0 0 2px hsl(216, 100%, 50%)",
+
+    // switch
+    switchWrapperHeight: "1.6rem",
+    switchWrapperHeightSm: "1.1rem",
+    switchWrapperWidth: "2.8rem",
+    switchWrapperWidthSm: "2.1rem",
+    wrapperBorderColor: "hsl(0, 0%, 90%)",
+    wrapperBgColor: "hsl(0, 0%, 90%)",
+    switchTrackerHeight: "1rem",
+    switchTrackerHeightSm: "0.7rem",
+    switchTrackerWidth: "1rem",
+    switchTrackerWidthSm: "0.7rem",
+    switchCheckedBorderColor: "hsl(118, 100%, 21%)",
+    switchCheckedBgColor: "hsl(118, 100%, 21%)",
+    switchCheckedDisabledBorderColor: "hsl(0, 0%, 90%)",
+    switchCheckedDisabledBgColor: "hsl(0, 0%, 90%)",
+    switchFocusColor: "hsl(216, 100%, 20%)",
+
+    // radio
+    smallRadioSize: "1.2rem",
+    mediumRadioSize: "1.4rem",
+    smallRadioBead: "0.6rem",
+    mediumRadioBead: "0.8rem",
+    radioDisabledColor: chromaPalette.Neutral10,
+
+    // Modal
+    modalBorder: `1px solid ${chromaPalette.Neutral30}`,
+    modalBorderRadius: "0.4rem",
+    modalMaxContentHeightOffset: 14,
+    modalPadding: {
+      vertical: 2.8,
+      horizontal: 2.1,
+    },
+    modalHeaderPadding: {
+      vertical: 1.4,
+      horizontal: 2.1,
+    },
+    modalTitleTypographySize: 20,
+    modalMinHeight: 35,
+  }
+
+  /**
+   * Passing general theme object with knitui property so it can
+   * merge with other nested ThemeProvider,
+   * https://github.com/styled-components/styled-components/issues/244#issuecomment-262577541
+   * it will emphasise ignorance of knitui-theme as property of
+   * whole theme object of styled-component
+   */
+  return {
+    knitui: { ...defaultTheme, chromaPalette },
+  }
 }
-
-// TODO: This mapping should be defined by UX
-export const secondaryPalette = {
-  neutral: chromaPalette.Blue100,
-  danger: chromaPalette.Crimson80,
-  success: chromaPalette.Green80,
-  warning: chromaPalette.Yellow80,
-  unsaved: chromaPalette.Magenta80,
-}
-
-// TODO: Remove this and its references and use chromaPallete directly
-export const shades = {
-  // Shades of gray
-  white: chromaPalette.Neutral0,
-  gray95: chromaPalette.Neutral10,
-  gray90: chromaPalette.Neutral20,
-  gray85: chromaPalette.Neutral30,
-  gray50: chromaPalette.Neutral50,
-  gray20: chromaPalette.Neutral80,
-  black: chromaPalette.Neutral90,
-  transparent: chroma.hsl(0, 0, 0, 0),
-
-  // Shades of blue
-  lightBlue: chromaPalette.Azure80,
-  blue40: chroma.hsl(205, 0.85, 0.4),
-  blue50: chroma.hsl(216, 1, 0.5),
-}
-
-// Properties
-export const lineHeight = "2rem"
-export const borderRadius = `${multiply(0.4, baseUnit)}px`
-export const defaultPadding = `${multiply(0.4, baseUnit)}px ${baseUnit}px`
-export const defaultTextPadding = "1.4rem"
-
-// input
-export const inputFocusOutline = "none"
-export const inputBgDefault = "hsl(0, 0%, 95%)"
-export const inputColor = "hsl(0, 0%, 5%)"
-export const inputPlaceholderColor = "hsl(0, 0%, 60%)"
-export const inputPlaceholderColorActive = "hsl(0, 0%, 80%)"
-export const inputBgHover = "hsl(0, 0%, 90%)"
-export const inputBgActive = "hsl(0, 0%, 100%)"
-export const inputBgFocus = "hsl(0,0%,100%)"
-export const inputBgDisabled = "hsl(0, 0%, 50%)"
-export const inputBorderRadius = "4px"
-export const inputBorderColor = "transparent"
-export const inputFocusBorderColor = chromaPalette.Azure80
-export const inputError = "#990000"
-export const inputSuccess = "#05b300"
-export const inputFocusBoxShadow = "0 0 2px hsl(216, 100%, 50%)"
-
-// switch
-export const switchWrapperHeight = "1.6rem"
-export const switchWrapperHeightSm = "1.1rem"
-export const switchWrapperWidth = "2.8rem"
-export const switchWrapperWidthSm = "2.1rem"
-export const wrapperBorderColor = "hsl(0, 0%, 90%)"
-export const wrapperBgColor = "hsl(0, 0%, 90%)"
-export const switchTrackerHeight = "1rem"
-export const switchTrackerHeightSm = "0.7rem"
-export const switchTrackerWidth = "1rem"
-export const switchTrackerWidthSm = "0.7rem"
-export const switchCheckedBorderColor = "hsl(118, 100%, 21%)"
-export const switchCheckedBgColor = "hsl(118, 100%, 21%)"
-export const switchCheckedDisabledBorderColor = "hsl(0, 0%, 90%)"
-export const switchCheckedDisabledBgColor = "hsl(0, 0%, 90%)"
-export const switchFocusColor = "hsl(216, 100%, 20%)"
-
-// radio
-export const smallRadioSize = "1.2rem"
-export const mediumRadioSize = "1.4rem"
-export const smallRadioBead = "0.6rem"
-export const mediumRadioBead = "0.8rem"
-export const radioDisabledColor = shades.gray95
-
-// Modal
-export const modalBorder = `1px solid ${shades.gray85}`
-export const modalBorderRadius = "0.4rem"
-export const modalMaxContentHeightOffset = 14 
-export const modalPadding = {
-  vertical: 2.8,
-  horizontal: 2.1,
-}
-export const modalHeaderPadding = {
-  vertical: 1.4,
-  horizontal: 2.1,
-}
-export const modalTitleTypographySize = 20
-export const modalMinHeight = 35
+export default generateTheme

--- a/src/components/Alerts/StyledAlert.tsx
+++ b/src/components/Alerts/StyledAlert.tsx
@@ -3,7 +3,7 @@ import styled, { css, keyframes } from "styled-components"
 import { AlertProps } from "./types"
 import { Icon, Button } from ".."
 
-import { IStyled, ColorPreset } from "../../common/types"
+import { IStyled } from "../../common/types"
 import { parseColorPreset, parseCustomColor } from "../../common/_utils"
 
 type IStyledAlert = IStyled<AlertProps>
@@ -65,8 +65,11 @@ const getHeadingLineHeight = (props: IStyledAlert) => {
 const parseColorTheme = (props: IStyledAlert) => {
   const {
     customProps: { customColor, type },
+    theme: { knitui: theme },
   } = props
-  return customColor ? parseCustomColor(customColor) : parseColorPreset(type!)
+  return customColor
+    ? parseCustomColor(theme, customColor)
+    : parseColorPreset(theme, type!)
 }
 
 const getBackgroundColor = (props: IStyledAlert) =>

--- a/src/components/Breadcrumb/BreadcrumbItem.tsx
+++ b/src/components/Breadcrumb/BreadcrumbItem.tsx
@@ -15,7 +15,7 @@ const sharedStyles = css<BreadcrumbItemProps>`
   align-items: center;
   &:hover {
     background-color: ${({ separator, theme: { knitui } }) =>
-      separator ? "" : knitui.shades.gray95};
+      separator ? "" : knitui.chromaPalette.Neutral10};
   }
   cursor: ${props => (props.separator ? "default" : "pointer")};
   a,
@@ -27,12 +27,12 @@ const sharedStyles = css<BreadcrumbItemProps>`
 
 export const StyledText = styled.span<BreadcrumbItemProps>`
   ${sharedStyles}
-  color: ${({ theme: { knitui } }) => knitui.shades.gray50};
+  color: ${({ theme: { knitui } }) => knitui.chromaPalette.Neutral50};
 `
 
 export const StyledActive = styled.span<BreadcrumbItemProps>`
   ${sharedStyles}
-  color: ${({ theme: { knitui } }) => knitui.shades.black}
+  color: ${({ theme: { knitui } }) => knitui.chromaPalette.Neutral90}
 `
 
 const BreadcrumbItem: SFC<BreadcrumbItemProps> = props => {

--- a/src/components/Button/ButtonWrapper.tsx
+++ b/src/components/Button/ButtonWrapper.tsx
@@ -42,16 +42,16 @@ const ButtonWrapper: React.FC<ButtonWrapperProps> = ({
 
   // Cannot be set as default arg since theme is not available in that context
   const DEFAULT_INSET_THEME = {
-    background: knitui.shades.white,
-    font: knitui.shades.gray20,
+    background: knitui.chromaPalette.Neutral0,
+    font: knitui.chromaPalette.Neutral80,
   }
 
   const insetColorTheme = insetCustomColor
-    ? parseCustomColor(insetCustomColor)
+    ? parseCustomColor(knitui, insetCustomColor)
     : DEFAULT_INSET_THEME
   const parsedColorTheme = customColor
-    ? parseCustomColor(customColor)
-    : parseColorPreset(colorPreset)
+    ? parseCustomColor(knitui, customColor)
+    : parseColorPreset(knitui, colorPreset)
 
   return (
     <ButtonBase

--- a/src/components/Button/components/ButtonBase.tsx
+++ b/src/components/Button/components/ButtonBase.tsx
@@ -158,7 +158,7 @@ const getBackgroundColor = (state: ButtonState, props: IStyledBaseButton) => {
   if (bare) {
     return state === "default"
       ? knitui.shades.transparent
-      : knitui.shades.gray95
+      : knitui.chromaPalette.Neutral10
   }
   if (ghost) {
     return knitui.chromaPalette.Neutral0 // white

--- a/src/components/Label/Label.tsx
+++ b/src/components/Label/Label.tsx
@@ -1,5 +1,5 @@
-import React from "react"
-import styled, { css } from "styled-components"
+import React, { useContext } from "react"
+import styled, { css, ThemeContext } from "styled-components"
 import Icon from "../Icon"
 import { ILabel, LabelPropTypes } from "./types"
 import InlineLabel from "./InlineLabel"
@@ -41,12 +41,16 @@ const getDarkenedBorderColor = (props: IStyledLabel) =>
   getBackgroundColor(props).set("hsl.l", "-0.2")
 
 const showLeftIcon = (props: IStyledLabel) => {
-  const { customProps: { icons } } = props
+  const {
+    customProps: { icons },
+  } = props
   return icons && icons.left
 }
 
 const showRightIcon = (props: IStyledLabel) => {
-  const { customProps: { icons } } = props
+  const {
+    customProps: { icons },
+  } = props
   return icons && icons.right
 }
 
@@ -57,12 +61,16 @@ const verticalPadding = {
 }
 
 const getVerticalPadding = (props: IStyledLabel) => {
-  const { customProps: { size } } = props
+  const {
+    customProps: { size },
+  } = props
   return verticalPadding[size!]
 }
 
 const getHorizontalPadding = (props: IStyledLabel) => {
-  const { customProps: { expanded } } = props
+  const {
+    customProps: { expanded },
+  } = props
   if (expanded) {
     return "1rem"
   }
@@ -70,7 +78,9 @@ const getHorizontalPadding = (props: IStyledLabel) => {
 }
 
 const getLeftPadding = (props: IStyledLabel) => {
-  const { customProps: { size } } = props
+  const {
+    customProps: { size },
+  } = props
   if (showLeftIcon(props)) {
     return size === "small" ? "0.3rem" : "0.5rem"
   }
@@ -78,7 +88,9 @@ const getLeftPadding = (props: IStyledLabel) => {
 }
 
 const getRightPadding = (props: IStyledLabel) => {
-  const { customProps: { size } } = props
+  const {
+    customProps: { size },
+  } = props
   if (showRightIcon(props)) {
     return size === "small" ? "0.3rem" : "0.5rem"
   }
@@ -118,20 +130,21 @@ const getBoxShadow = (props: IStyledLabel) => {
 
 const getInsetStyles = (props: IStyledLabel) => {
   const { insetColor } = props
-  return insetColor ? css`
-    &::before {
-      content: "";
-      position: absolute;
-      top: 0;
-      bottom: 0;
-      left: 0;
-      width: 0.3rem;
-      background: ${insetColor};
-      border-radius: 0.2rem 0  0 0.2rem;
-    }
-  ` : ""
+  return insetColor
+    ? css`
+        &::before {
+          content: "";
+          position: absolute;
+          top: 0;
+          bottom: 0;
+          left: 0;
+          width: 0.3rem;
+          background: ${insetColor};
+          border-radius: 0.2rem 0 0 0.2rem;
+        }
+      `
+    : ""
 }
-
 
 const StyledDiv = styled.div<IStyledLabel>`
   position: relative;
@@ -163,31 +176,36 @@ const Label: ILabel = props => {
   const { className, style, ...rest } = props
   const { text, icons, insetColor } = rest
   /**
+   * Styled Component theme should be needed here, because getFontColor take theme
+   * as argument
+   */
+  const theme = useContext(ThemeContext)
+  /**
    * If an insetColor is specified, the background color should be set to a default unless
-   * explicitly provided through customColor 
+   * explicitly provided through customColor
    */
   if (insetColor) {
     rest.customColor = rest.customColor || INSET_BACKGROUND_COLOR
-  } 
-  const scProps = { className, style, customProps: rest }
+  }
+  const scProps = { className, style, theme, customProps: rest }
   //For styled components, we separate the props that are to be loaded on the DOM
   return (
     <StyledDiv {...scProps} insetColor={insetColor}>
-        {showLeftIcon(scProps) ? (
-          <LeftIcon
-            {...scProps}
-            fill={getFontColor(scProps)}
-            type={icons!.left}
-          />
-        ) : null}
-        <span>{text}</span>
-        {showRightIcon(scProps) ? (
-          <RightIcon
-            {...scProps}
-            fill={getFontColor(scProps)}
-            type={icons!.right}
-          />
-        ) : null}
+      {showLeftIcon(scProps) ? (
+        <LeftIcon
+          {...scProps}
+          fill={getFontColor(scProps)}
+          type={icons!.left}
+        />
+      ) : null}
+      <span>{text}</span>
+      {showRightIcon(scProps) ? (
+        <RightIcon
+          {...scProps}
+          fill={getFontColor(scProps)}
+          type={icons!.right}
+        />
+      ) : null}
     </StyledDiv>
   )
 }

--- a/src/components/Label/commonUtils.ts
+++ b/src/components/Label/commonUtils.ts
@@ -7,14 +7,20 @@ type IStyledInlineLabel = IStyled<InlineLabelProps>
 type GenericLabelProps = IStyledLabel | IStyledInlineLabel
 
 export const parseColorTheme = (props: GenericLabelProps) => {
-  const { customProps: { customColor, colorPreset } } = props
+  const {
+    customProps: { customColor, colorPreset },
+    theme: { knitui: theme },
+  } = props
   return customColor
-    ? parseCustomColor(customColor)
-    : parseColorPreset(colorPreset!)
+    ? parseCustomColor(theme, customColor)
+    : parseColorPreset(theme, colorPreset!)
 }
-export const getBackgroundColor = (props: GenericLabelProps) => parseColorTheme(props).background
+export const getBackgroundColor = (props: GenericLabelProps) =>
+  parseColorTheme(props).background
 
 export const getFontColor = (props: GenericLabelProps) => {
-  const { customProps: { customFontColor } } = props
+  const {
+    customProps: { customFontColor },
+  } = props
   return customFontColor || parseColorTheme(props).font
 }

--- a/src/components/Modal/ModalWrapper.tsx
+++ b/src/components/Modal/ModalWrapper.tsx
@@ -15,7 +15,6 @@ import {
 import Icon from "../Icon"
 import "rc-dialog/assets/index.css"
 
-
 const sizeToWidth = {
   small: "49rem",
   medium: "63rem",
@@ -53,10 +52,11 @@ const StyledDialog = styled(Dialog)<IStyledDialog>`
     opacity: unset;
     padding: 0.15rem;
     line-height: 0;
-    background-color: ${({ theme: { knitui } }) => knitui.shades.gray50};
+    background-color: ${({ theme: { knitui } }) =>
+      knitui.chromaPalette.Neutral50};
     border-radius: 999px;
     svg {
-        fill: ${({ theme: { knitui } }) => knitui.shades.gray90};
+        fill: ${({ theme: { knitui } }) => knitui.chromaPalette.Neutral20};
       }
     }
   }
@@ -120,7 +120,7 @@ const ModalWrapper: React.FC<ModalWrapperProps> = ({
   destroyOnClose,
   className,
   style,
-  padding
+  padding,
 }) => {
   /**
    * Renders the appopriate variant based on the availability of a
@@ -184,7 +184,11 @@ const ModalWrapper: React.FC<ModalWrapperProps> = ({
         maxContentHeight={maxContentHeight}
         minContentHeight={minContentHeight}
         header={<Header {...header} />}
-        body={<Main customProps={{padding}} ref={setBodyRef}>{body}</Main>}
+        body={
+          <Main customProps={{ padding }} ref={setBodyRef}>
+            {body}
+          </Main>
+        }
         footer={
           <Footer customProps={{ showBorder: showFooterBorder }}>
             {footer}

--- a/src/components/Modal/components/Header.tsx
+++ b/src/components/Modal/components/Header.tsx
@@ -1,9 +1,6 @@
 import React, { ReactNode } from "react"
 import styled from "styled-components"
-import {
-  IStyled,
-  fontSizeType
-} from "../../../common/types"
+import { IStyled, fontSizeType } from "../../../common/types"
 
 /**
  * This type definintion has common elments from the parent (ModalWrapper)
@@ -11,24 +8,30 @@ import {
  * the places instead of having them duplicated.
  */
 interface HeaderProps {
-  title: string;
-  fontSize?: fontSizeType,
-  rightSection?: ReactNode,
-  noFill?: boolean,
+  title: string
+  fontSize?: fontSizeType
+  rightSection?: ReactNode
+  noFill?: boolean
 }
 
 type IStyledHeaderProps = IStyled<HeaderProps>
 
-const VERTICAL_PADDING = 1.4;
+const VERTICAL_PADDING = 1.4
 
 const getFontSize = (props: IStyledHeaderProps) => {
-  const { customProps: { fontSize }, theme: { knitui } } = props
+  const {
+    customProps: { fontSize },
+    theme: { knitui },
+  } = props
   const typographySize = fontSize || knitui.modalTitleTypographySize
   return `${knitui.typography[typographySize].fontSize}rem`
 }
 
 const getLineHeight = (props: IStyledHeaderProps) => {
-  const { customProps: { fontSize }, theme: { knitui } } = props
+  const {
+    customProps: { fontSize },
+    theme: { knitui },
+  } = props
   const typographySize = fontSize || knitui.modalTitleTypographySize
   return knitui.typography[typographySize].lineHeight
 }
@@ -44,14 +47,16 @@ const Container = styled.div<IStyledHeaderProps>`
     `${knitui.modalHeaderPadding.vertical}rem ${knitui.modalHeaderPadding.horizontal}rem`};
   border-radius: ${({ theme: { knitui } }) =>
     `${knitui.modalBorderRadius} ${knitui.modalBorderRadius} 0rem 0rem`};
-  background: ${({ theme: { knitui }, customProps: { noFill } }) => noFill ? "none" : knitui.shades.gray95};
-  border-bottom: ${({ customProps: { noFill }, theme: { knitui }}) => noFill ? knitui.modalBorder : "none"};
-  min-height: ${props => `${getMinHeight(props)}rem`}
+  background: ${({ theme: { knitui }, customProps: { noFill } }) =>
+    noFill ? "none" : knitui.chromaPalette.Neutral10};
+  border-bottom: ${({ customProps: { noFill }, theme: { knitui } }) =>
+    noFill ? knitui.modalBorder : "none"};
+  min-height: ${props => `${getMinHeight(props)}rem`};
 `
 const TitleSection = styled.div<IStyledHeaderProps>`
-  font-size: ${props => getFontSize(props) };
+  font-size: ${props => getFontSize(props)};
   line-height: ${props => `${getLineHeight(props)}rem`};
-  color: ${({ theme: { knitui } }) => knitui.shades.gray20};
+  color: ${({ theme: { knitui } }) => knitui.chromaPalette.Neutral80};
   margin-right: 1.4rem;
 `
 
@@ -61,7 +66,7 @@ const RightSection = styled.div`
   align-items: center;
 `
 
-const Header: React.FC<HeaderProps> = props => { 
+const Header: React.FC<HeaderProps> = props => {
   const { title, rightSection } = props
   const scProps = { customProps: props }
   return (


### PR DESCRIPTION
  include a prop to pass custom/modified theme to themeprovider,

	* Create function to generate theme, palette as arguments

	* Utils functions refactoring, added argument theme, untill now it directly accessing default theme

  So know we are exposing `{ palette, generateTheme }` along with `{ ThemeProvider }` in import.

- One additional things replaced some shades colors with chromaPalette colors.