### PR TITLE
Add custom addon support in labels

### DIFF
--- a/src/components/Label/Label.stories.tsx
+++ b/src/components/Label/Label.stories.tsx
@@ -1,6 +1,7 @@
 import React from "react"
 import { storiesOf } from "@storybook/react"
 import Label from "./"
+import { Icon } from ".."
 import {
   withKnobs,
   text,
@@ -8,6 +9,7 @@ import {
   select,
   object,
 } from "@storybook/addon-knobs"
+import { action } from "@storybook/addon-actions"
 const Readme = require("./README.md")
 
 const stories = storiesOf("Labels", module)
@@ -113,6 +115,18 @@ stories
       outlined={boolean("Outlined", false)}
       focus={boolean("Focus", false)}
       icons={{ right: "oClose" }}
+    />
+  ))
+  .add("With a custom right addon", () => (
+    <Label
+      text={text("text", "Label")}
+      expanded={boolean("Expanded", false)}
+      size={select("Size", sizeOptions, "medium")}
+      colorPreset={select("Color preset", colorThemeOptions, "neutral")}
+      rounded={boolean("Rounded", false)}
+      outlined={boolean("Outlined", false)}
+      focus={boolean("Focus", false)}
+      icons={{ right: (<Icon type="oClose" style={{cursor: "pointer"}} fill="#FFFFFF" onClick={action("icon click")} />) }}
     />
   ))
   .add("With a left and a right icons", () => (

--- a/src/components/Label/Label.tsx
+++ b/src/components/Label/Label.tsx
@@ -1,5 +1,6 @@
 import React, { useContext } from "react"
 import styled, { css, ThemeContext } from "styled-components"
+import _ from "lodash"
 import Icon from "../Icon"
 import { ILabel, LabelPropTypes } from "./types"
 import InlineLabel from "./InlineLabel"
@@ -187,25 +188,47 @@ const Label: ILabel = props => {
   if (insetColor) {
     rest.customColor = rest.customColor || INSET_BACKGROUND_COLOR
   }
+
   const scProps = { className, style, theme, customProps: rest }
-  //For styled components, we separate the props that are to be loaded on the DOM
-  return (
-    <StyledDiv {...scProps} insetColor={insetColor}>
-      {showLeftIcon(scProps) ? (
+
+  const renderLeftIcon = () => {
+    if (!showLeftIcon(scProps)) {
+      return null
+    }
+    if (_.isString(icons!.left)) {
+      return (
         <LeftIcon
           {...scProps}
           fill={getFontColor(scProps)}
           type={icons!.left}
         />
-      ) : null}
-      <span>{text}</span>
-      {showRightIcon(scProps) ? (
+      )
+    }
+    return icons!.left
+  }
+
+  const renderRightIcon = () => {
+    if (!showRightIcon(scProps)) {
+      return null
+    }
+    if (_.isString(icons!.right)) {
+      return (
         <RightIcon
           {...scProps}
           fill={getFontColor(scProps)}
           type={icons!.right}
         />
-      ) : null}
+      )
+    }
+    return icons!.right
+  }
+
+  //For styled components, we separate the props that are to be loaded on the DOM
+  return (
+    <StyledDiv {...scProps} insetColor={insetColor}>
+      {renderLeftIcon()}
+      <span>{text}</span>
+      {renderRightIcon()}
     </StyledDiv>
   )
 }

--- a/src/components/Label/Label.tsx
+++ b/src/components/Label/Label.tsx
@@ -98,11 +98,19 @@ const getRightPadding = (props: IStyledLabel) => {
   return getHorizontalPadding(props)
 }
 
-const getIconMargin = (props: IStyledLabel) => {
+const getTextMargin = (props: IStyledLabel) => {
   const {
     customProps: { size },
   } = props
   return size === "small" ? "0.2rem" : "0.4rem"
+}
+
+const getTextLeftMargin = (props: IStyledLabel) => {
+  return showLeftIcon(props) ? getTextMargin(props) : "0rem"
+}
+
+const getTextRightMargin = (props: IStyledLabel) => {
+  return showRightIcon(props) ? getTextMargin(props) : "0rem"
 }
 
 const getBorderColor = (props: IStyledLabel) => {
@@ -167,12 +175,10 @@ const StyledDiv = styled.div<IStyledLabel>`
   ${props => getInsetStyles(props)}
 `
 
-const LeftIcon = styled(Icon)<IStyledLabel>`
-  margin-right: ${props => getIconMargin(props)};
+const StyledTextSpan = styled.span<IStyledLabel>`
+  margin: 0rem ${props => getTextRightMargin(props)} 0rem ${props => getTextLeftMargin(props)};
 `
-const RightIcon = styled(Icon)<IStyledLabel>`
-  margin-left: ${props => getIconMargin(props)};
-`
+
 const Label: ILabel = props => {
   const { className, style, ...rest } = props
   const { text, icons, insetColor } = rest
@@ -197,8 +203,7 @@ const Label: ILabel = props => {
     }
     if (_.isString(icons!.left)) {
       return (
-        <LeftIcon
-          {...scProps}
+        <Icon
           fill={getFontColor(scProps)}
           type={icons!.left}
         />
@@ -213,8 +218,7 @@ const Label: ILabel = props => {
     }
     if (_.isString(icons!.right)) {
       return (
-        <RightIcon
-          {...scProps}
+        <Icon
           fill={getFontColor(scProps)}
           type={icons!.right}
         />
@@ -227,7 +231,7 @@ const Label: ILabel = props => {
   return (
     <StyledDiv {...scProps} insetColor={insetColor}>
       {renderLeftIcon()}
-      <span>{text}</span>
+      <StyledTextSpan {...scProps} >{text}</StyledTextSpan>
       {renderRightIcon()}
     </StyledDiv>
   )

--- a/src/components/Label/README.md
+++ b/src/components/Label/README.md
@@ -22,7 +22,7 @@ import { Label } from "KnitUI"
 | rounded  | boolean | Yes | `false` | Whether the label should have rounded edges |
 | outlined  | boolean | Yes | `false` |  Whether the label be outlined |
 | focus  | boolean | Yes | `false ` | Label is focussed or being dragge |
-| icons    | `[{left: string, right: string}]`  | No | None    |  Icons to be rendered in the label. They can be on left, a right or on both sides of the text |
+| icons    | `{left: string | ReactNode, right: string | ReactNode}`  | No | None    |  Icons to be rendered in the label. They can be on left, a right or on both sides of the text |
 | className | string | Yes | None | CSS class name to be added |
 | style | CSS Object | Yes | None | CSS style to be added |
 | insetColor | string | Yes | None | If provided, will add a small decoration on the label with the given color. Also the background is set to a default which can be changed by `customColor` but not through the `colorPreset` |

--- a/src/components/Label/__tests__/Label.test.tsx
+++ b/src/components/Label/__tests__/Label.test.tsx
@@ -1,5 +1,6 @@
 import React from "react"
 import Label from "../"
+import { Icon } from "../../"
 import { render, cleanup } from "react-testing-library"
 import { ThemeProvider } from "../../../common/styles"
 import "jest-styled-components"
@@ -66,6 +67,15 @@ describe("Label", () => {
         expect(asFragment()).toMatchSnapshot()
       })
     })
+  })
+
+  it("right custom addon", () => {
+    const { asFragment } = render(
+      <ThemeProvider>
+        <Label text="label" icons={{ right: <Icon type="oClose" style={{cursor: "pointer"}} fill="#FFFFFF" /> }} />
+      </ThemeProvider>
+    )
+    expect(asFragment()).toMatchSnapshot()
   })
 
   it("outlined", () => {

--- a/src/components/Label/__tests__/__snapshots__/Label.test.tsx.snap
+++ b/src/components/Label/__tests__/__snapshots__/Label.test.tsx.snap
@@ -24,10 +24,16 @@ exports[`Label custom class 1`] = `
   overflow: hidden;
 }
 
+.c1 {
+  margin: 0rem 0rem 0rem 0rem;
+}
+
 <div
     class="custom-class c0"
   >
-    <span>
+    <span
+      class="custom-class c1"
+    >
       label
     </span>
   </div>
@@ -58,10 +64,16 @@ exports[`Label custom font color 1`] = `
   overflow: hidden;
 }
 
+.c1 {
+  margin: 0rem 0rem 0rem 0rem;
+}
+
 <div
     class="c0"
   >
-    <span>
+    <span
+      class="c1"
+    >
       label
     </span>
   </div>
@@ -92,11 +104,18 @@ exports[`Label custom style 1`] = `
   overflow: hidden;
 }
 
+.c1 {
+  margin: 0rem 0rem 0rem 0rem;
+}
+
 <div
     class="c0"
     style="background-color: red;"
   >
-    <span>
+    <span
+      class="c1"
+      style="background-color: red;"
+    >
       label
     </span>
   </div>
@@ -127,10 +146,16 @@ exports[`Label focused 1`] = `
   overflow: hidden;
 }
 
+.c1 {
+  margin: 0rem 0rem 0rem 0rem;
+}
+
 <div
     class="c0"
   >
-    <span>
+    <span
+      class="c1"
+    >
       label
     </span>
   </div>
@@ -230,10 +255,16 @@ exports[`Label inset 1`] = `
   border-radius: 0.2rem 0 0 0.2rem;
 }
 
+.c1 {
+  margin: 0rem 0rem 0rem 0rem;
+}
+
 <div
     class="c0"
   >
-    <span>
+    <span
+      class="c1"
+    >
       label
     </span>
   </div>
@@ -275,10 +306,16 @@ exports[`Label inset with custom color 1`] = `
   border-radius: 0.2rem 0 0 0.2rem;
 }
 
+.c1 {
+  margin: 0rem 0rem 0rem 0rem;
+}
+
 <div
     class="c0"
   >
-    <span>
+    <span
+      class="c1"
+    >
       label
     </span>
   </div>
@@ -309,10 +346,16 @@ exports[`Label outlined 1`] = `
   overflow: hidden;
 }
 
+.c1 {
+  margin: 0rem 0rem 0rem 0rem;
+}
+
 <div
     class="c0"
   >
-    <span>
+    <span
+      class="c1"
+    >
       label
     </span>
   </div>
@@ -321,7 +364,7 @@ exports[`Label outlined 1`] = `
 
 exports[`Label right custom addon 1`] = `
 <DocumentFragment>
-  .c1 {
+  .c2 {
   cursor: inherit;
   display: inline-block;
   height: 18px;
@@ -350,14 +393,20 @@ exports[`Label right custom addon 1`] = `
   overflow: hidden;
 }
 
+.c1 {
+  margin: 0rem 0.4rem 0rem 0rem;
+}
+
 <div
     class="c0"
   >
-    <span>
+    <span
+      class="c1"
+    >
       label
     </span>
     <span
-      class="c1"
+      class="c2"
       fill="#FFFFFF"
       height="18px"
       style="cursor: pointer;"
@@ -404,10 +453,16 @@ exports[`Label rounded 1`] = `
   overflow: hidden;
 }
 
+.c1 {
+  margin: 0rem 0rem 0rem 0rem;
+}
+
 <div
     class="c0"
   >
-    <span>
+    <span
+      class="c1"
+    >
       label
     </span>
   </div>
@@ -438,10 +493,16 @@ exports[`Label with size large compact 1`] = `
   overflow: hidden;
 }
 
+.c1 {
+  margin: 0rem 0rem 0rem 0rem;
+}
+
 <div
     class="c0"
   >
-    <span>
+    <span
+      class="c1"
+    >
       label
     </span>
   </div>
@@ -472,10 +533,16 @@ exports[`Label with size large expanded 1`] = `
   overflow: hidden;
 }
 
+.c1 {
+  margin: 0rem 0rem 0rem 0rem;
+}
+
 <div
     class="c0"
   >
-    <span>
+    <span
+      class="c1"
+    >
       label
     </span>
   </div>
@@ -484,7 +551,7 @@ exports[`Label with size large expanded 1`] = `
 
 exports[`Label with size large left and right icons 1`] = `
 <DocumentFragment>
-  .c2 {
+  .c1 {
   cursor: inherit;
   display: inline-block;
   height: 18px;
@@ -513,19 +580,15 @@ exports[`Label with size large left and right icons 1`] = `
   overflow: hidden;
 }
 
-.c1 {
-  margin-right: 0.4rem;
-}
-
-.c3 {
-  margin-left: 0.4rem;
+.c2 {
+  margin: 0rem 0.4rem 0rem 0.4rem;
 }
 
 <div
     class="c0"
   >
     <span
-      class="c1 c2"
+      class="c1"
       fill="#ffffff"
       height="18px"
       type="oDragIndicator"
@@ -543,11 +606,13 @@ exports[`Label with size large left and right icons 1`] = `
         />
       </svg>
     </span>
-    <span>
+    <span
+      class="c2"
+    >
       label
     </span>
     <span
-      class="c3 c2"
+      class="c1"
       fill="#ffffff"
       height="18px"
       type="oClose"
@@ -571,7 +636,7 @@ exports[`Label with size large left and right icons 1`] = `
 
 exports[`Label with size large left icon 1`] = `
 <DocumentFragment>
-  .c2 {
+  .c1 {
   cursor: inherit;
   display: inline-block;
   height: 18px;
@@ -600,15 +665,15 @@ exports[`Label with size large left icon 1`] = `
   overflow: hidden;
 }
 
-.c1 {
-  margin-right: 0.4rem;
+.c2 {
+  margin: 0rem 0rem 0rem 0.4rem;
 }
 
 <div
     class="c0"
   >
     <span
-      class="c1 c2"
+      class="c1"
       fill="#ffffff"
       height="18px"
       type="oDragIndicator"
@@ -626,7 +691,9 @@ exports[`Label with size large left icon 1`] = `
         />
       </svg>
     </span>
-    <span>
+    <span
+      class="c2"
+    >
       label
     </span>
   </div>
@@ -665,17 +732,19 @@ exports[`Label with size large right icon 1`] = `
 }
 
 .c1 {
-  margin-left: 0.4rem;
+  margin: 0rem 0.4rem 0rem 0rem;
 }
 
 <div
     class="c0"
   >
-    <span>
+    <span
+      class="c1"
+    >
       label
     </span>
     <span
-      class="c1 c2"
+      class="c2"
       fill="#ffffff"
       height="18px"
       type="oClose"
@@ -721,10 +790,16 @@ exports[`Label with size medium compact 1`] = `
   overflow: hidden;
 }
 
+.c1 {
+  margin: 0rem 0rem 0rem 0rem;
+}
+
 <div
     class="c0"
   >
-    <span>
+    <span
+      class="c1"
+    >
       label
     </span>
   </div>
@@ -755,10 +830,16 @@ exports[`Label with size medium expanded 1`] = `
   overflow: hidden;
 }
 
+.c1 {
+  margin: 0rem 0rem 0rem 0rem;
+}
+
 <div
     class="c0"
   >
-    <span>
+    <span
+      class="c1"
+    >
       label
     </span>
   </div>
@@ -767,7 +848,7 @@ exports[`Label with size medium expanded 1`] = `
 
 exports[`Label with size medium left and right icons 1`] = `
 <DocumentFragment>
-  .c2 {
+  .c1 {
   cursor: inherit;
   display: inline-block;
   height: 18px;
@@ -796,19 +877,15 @@ exports[`Label with size medium left and right icons 1`] = `
   overflow: hidden;
 }
 
-.c1 {
-  margin-right: 0.4rem;
-}
-
-.c3 {
-  margin-left: 0.4rem;
+.c2 {
+  margin: 0rem 0.4rem 0rem 0.4rem;
 }
 
 <div
     class="c0"
   >
     <span
-      class="c1 c2"
+      class="c1"
       fill="#ffffff"
       height="18px"
       type="oDragIndicator"
@@ -826,11 +903,13 @@ exports[`Label with size medium left and right icons 1`] = `
         />
       </svg>
     </span>
-    <span>
+    <span
+      class="c2"
+    >
       label
     </span>
     <span
-      class="c3 c2"
+      class="c1"
       fill="#ffffff"
       height="18px"
       type="oClose"
@@ -854,7 +933,7 @@ exports[`Label with size medium left and right icons 1`] = `
 
 exports[`Label with size medium left icon 1`] = `
 <DocumentFragment>
-  .c2 {
+  .c1 {
   cursor: inherit;
   display: inline-block;
   height: 18px;
@@ -883,15 +962,15 @@ exports[`Label with size medium left icon 1`] = `
   overflow: hidden;
 }
 
-.c1 {
-  margin-right: 0.4rem;
+.c2 {
+  margin: 0rem 0rem 0rem 0.4rem;
 }
 
 <div
     class="c0"
   >
     <span
-      class="c1 c2"
+      class="c1"
       fill="#ffffff"
       height="18px"
       type="oDragIndicator"
@@ -909,7 +988,9 @@ exports[`Label with size medium left icon 1`] = `
         />
       </svg>
     </span>
-    <span>
+    <span
+      class="c2"
+    >
       label
     </span>
   </div>
@@ -948,17 +1029,19 @@ exports[`Label with size medium right icon 1`] = `
 }
 
 .c1 {
-  margin-left: 0.4rem;
+  margin: 0rem 0.4rem 0rem 0rem;
 }
 
 <div
     class="c0"
   >
-    <span>
+    <span
+      class="c1"
+    >
       label
     </span>
     <span
-      class="c1 c2"
+      class="c2"
       fill="#ffffff"
       height="18px"
       type="oClose"
@@ -1004,10 +1087,16 @@ exports[`Label with size small compact 1`] = `
   overflow: hidden;
 }
 
+.c1 {
+  margin: 0rem 0rem 0rem 0rem;
+}
+
 <div
     class="c0"
   >
-    <span>
+    <span
+      class="c1"
+    >
       label
     </span>
   </div>
@@ -1038,10 +1127,16 @@ exports[`Label with size small expanded 1`] = `
   overflow: hidden;
 }
 
+.c1 {
+  margin: 0rem 0rem 0rem 0rem;
+}
+
 <div
     class="c0"
   >
-    <span>
+    <span
+      class="c1"
+    >
       label
     </span>
   </div>
@@ -1050,7 +1145,7 @@ exports[`Label with size small expanded 1`] = `
 
 exports[`Label with size small left and right icons 1`] = `
 <DocumentFragment>
-  .c2 {
+  .c1 {
   cursor: inherit;
   display: inline-block;
   height: 18px;
@@ -1079,19 +1174,15 @@ exports[`Label with size small left and right icons 1`] = `
   overflow: hidden;
 }
 
-.c1 {
-  margin-right: 0.2rem;
-}
-
-.c3 {
-  margin-left: 0.2rem;
+.c2 {
+  margin: 0rem 0.2rem 0rem 0.2rem;
 }
 
 <div
     class="c0"
   >
     <span
-      class="c1 c2"
+      class="c1"
       fill="#ffffff"
       height="18px"
       type="oDragIndicator"
@@ -1109,11 +1200,13 @@ exports[`Label with size small left and right icons 1`] = `
         />
       </svg>
     </span>
-    <span>
+    <span
+      class="c2"
+    >
       label
     </span>
     <span
-      class="c3 c2"
+      class="c1"
       fill="#ffffff"
       height="18px"
       type="oClose"
@@ -1137,7 +1230,7 @@ exports[`Label with size small left and right icons 1`] = `
 
 exports[`Label with size small left icon 1`] = `
 <DocumentFragment>
-  .c2 {
+  .c1 {
   cursor: inherit;
   display: inline-block;
   height: 18px;
@@ -1166,15 +1259,15 @@ exports[`Label with size small left icon 1`] = `
   overflow: hidden;
 }
 
-.c1 {
-  margin-right: 0.2rem;
+.c2 {
+  margin: 0rem 0rem 0rem 0.2rem;
 }
 
 <div
     class="c0"
   >
     <span
-      class="c1 c2"
+      class="c1"
       fill="#ffffff"
       height="18px"
       type="oDragIndicator"
@@ -1192,7 +1285,9 @@ exports[`Label with size small left icon 1`] = `
         />
       </svg>
     </span>
-    <span>
+    <span
+      class="c2"
+    >
       label
     </span>
   </div>
@@ -1231,17 +1326,19 @@ exports[`Label with size small right icon 1`] = `
 }
 
 .c1 {
-  margin-left: 0.2rem;
+  margin: 0rem 0.2rem 0rem 0rem;
 }
 
 <div
     class="c0"
   >
-    <span>
+    <span
+      class="c1"
+    >
       label
     </span>
     <span
-      class="c1 c2"
+      class="c2"
       fill="#ffffff"
       height="18px"
       type="oClose"

--- a/src/components/Label/__tests__/__snapshots__/Label.test.tsx.snap
+++ b/src/components/Label/__tests__/__snapshots__/Label.test.tsx.snap
@@ -319,6 +319,67 @@ exports[`Label outlined 1`] = `
 </DocumentFragment>
 `;
 
+exports[`Label right custom addon 1`] = `
+<DocumentFragment>
+  .c1 {
+  cursor: inherit;
+  display: inline-block;
+  height: 18px;
+  width: 18px;
+}
+
+.c0 {
+  position: relative;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  padding: 0.2rem 0.5rem 0.2rem 0.7rem;
+  background-color: #002966;
+  color: #ffffff;
+  font-size: 1.4rem;
+  line-height: 2rem;
+  border-radius: 0.2rem;
+  border: 1px solid transparent;
+  box-sizing: border-box;
+  box-shadow: none;
+  overflow: hidden;
+}
+
+<div
+    class="c0"
+  >
+    <span>
+      label
+    </span>
+    <span
+      class="c1"
+      fill="#FFFFFF"
+      height="18px"
+      style="cursor: pointer;"
+      type="oClose"
+      width="18px"
+    >
+      <svg
+        fill="#FFFFFF"
+        height="18px"
+        viewBox="0 0 24 24"
+        width="18px"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M19 6.41L17.59 5L12 10.59L6.41 5L5 6.41L10.59 12L5 17.59L6.41 19L12 13.41L17.59 19L19 17.59L13.41 12L19 6.41Z"
+        />
+      </svg>
+    </span>
+  </div>
+</DocumentFragment>
+`;
+
 exports[`Label rounded 1`] = `
 <DocumentFragment>
   .c0 {

--- a/src/components/Label/types.ts
+++ b/src/components/Label/types.ts
@@ -4,7 +4,7 @@ import {
   BaseComponentProps,
   fontSizeType,
 } from "../../common/types"
-import React from "react"
+import React, { ReactNode } from "react"
 
 export interface BaseLabelProps extends BaseComponentProps {
   /** Text to be rendered on the label */
@@ -38,7 +38,7 @@ export interface LabelPropTypes extends BaseLabelProps {
    * Icons to be rendered in the label. They can be on left,
    * a right or on both sides of the text
    * */
-  icons?: { left?: string; right?: string }
+  icons?: { left?: string | ReactNode; right?: string | ReactNode }
   /** Label is focussed or being dragged */
   focus?: boolean
   /** If an inset color should be used. If provided, will add a small decoration on the label

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,7 +20,7 @@
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
     "esModuleInterop": true, // enable --allowSyntheticDefaultImports for typesystem compatibility.
-    "skipLibCheck": true,
+    "skipLibCheck": true
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "build", "scripts", "build"]


### PR DESCRIPTION
Allows passing components as left and right icons in addition to just strings (icon types).