### PR TITLE
Adding Props to ButtonGroup

### DIFF
--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -246,3 +246,51 @@ stories
       </ButtonGroup>
     )
   })
+  .add("Button Group Custom Style & Classname", () => {
+    const defaultStyle = {
+      border: "1px solid red",
+      borderRadius: "4px",
+    }
+    const style = object("style", defaultStyle)
+    const className = text("text", "HelloGroup")
+
+    // props which should be same for all Buttons in ButtonGroup
+    const type = options("type", typeOptions, "primary", {
+      display: "inline-radio",
+    })
+    const size = options("size", sizeOptions, "medium", {
+      display: "inline-radio",
+    })
+    const colorPreset = options("colorPreset", colorThemeOptions, "neutral", {
+      display: "inline-radio",
+    })
+    const ghost = boolean("ghost", false)
+    const disabled = boolean("disabled", false)
+    const bare = boolean("bare", false)
+    return (
+      <ButtonGroup style={style} className={className}>
+        <Button
+          label={text("Label 2", "Dropdown")}
+          type={type}
+          size={size}
+          colorPreset={colorPreset}
+          ghost={ghost}
+          disabled={disabled}
+          bare={bare}
+          onClick={action("button-click 2")}
+          icon={text("Icon 2", "")}
+        />
+        <Button
+          label={text("Label 3", "")}
+          type={type}
+          size={size}
+          colorPreset={colorPreset}
+          ghost={ghost}
+          disabled={disabled}
+          bare={bare}
+          onClick={action("button-click 3")}
+          icon={text("Icon 3", "oExpandMore")}
+        />
+      </ButtonGroup>
+    )
+  })

--- a/src/components/Button/ButtonGroup.tsx
+++ b/src/components/Button/ButtonGroup.tsx
@@ -1,8 +1,9 @@
 import React, { ReactNode, ReactElement } from "react"
 import styled from "styled-components"
 import { ButtonBase } from "./components"
+import { BaseComponentProps } from "../../common/types"
 
-const getStyleForGhostButtons = props => {
+const getStyleForGhostButtons = (props: ButtonGroupWrapperProps) => {
   const style = props.isAllGhost
     ? `
         & ${ButtonBase}:not(:last-of-type){
@@ -39,12 +40,13 @@ const StyledVerticalBar = styled.hr`
   z-index: 1;
 `
 
-type ButtonGroupWrapperProps = {
+interface ButtonGroupWrapperProps extends ButtonGroupProps {
   isAllGhost: boolean
-  children: ReactNode
 }
 const ButtonGroupWrapper = styled.div<ButtonGroupWrapperProps>`
-  display: flex;
+  //To have width equal to all of it's child component.
+  display: inline-flex;
+
   & ${ButtonBase} {
     border-radius: 0rem;
   }
@@ -61,9 +63,13 @@ const ButtonGroupWrapper = styled.div<ButtonGroupWrapperProps>`
   ${props => getStyleForGhostButtons(props)}
 `
 
-const ButtonGroup: React.FC = props => {
+interface ButtonGroupProps extends BaseComponentProps {
+  children: ReactNode
+  [htmlProp: string]: any
+}
+const ButtonGroup: React.FC<ButtonGroupProps> = props => {
   const childrenCount = React.Children.count(props.children)
-
+  const { children, ...rest } = props
   let countGhost = 0
   React.Children.forEach(props.children, (child: ReactElement, i) => {
     if (child.props.ghost) countGhost += 1
@@ -71,7 +77,7 @@ const ButtonGroup: React.FC = props => {
 
   const isAllGhost = countGhost === childrenCount ? true : false
   return (
-    <ButtonGroupWrapper isAllGhost={isAllGhost}>
+    <ButtonGroupWrapper isAllGhost={isAllGhost} {...rest}>
       {React.Children.map(props.children, (child: ReactElement, i: Number) =>
         i == childrenCount - 1 ? (
           child

--- a/src/components/Button/__tests__/__snapshots__/Button.test.tsx.snap
+++ b/src/components/Button/__tests__/__snapshots__/Button.test.tsx.snap
@@ -45,6 +45,7 @@ exports[`Button Group :  Button group : snapshot 1`] = `
 .c5:focus {
   color: #ffffff;
   background-color: #003d99;
+  cursor: pointer;
 }
 
 .c5:hover svg path,
@@ -105,6 +106,7 @@ exports[`Button Group :  Button group : snapshot 1`] = `
 .c2:focus {
   color: #ffffff;
   background-color: #003d99;
+  cursor: pointer;
 }
 
 .c2:hover svg path,
@@ -137,10 +139,10 @@ exports[`Button Group :  Button group : snapshot 1`] = `
 }
 
 .c0 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
 }
 
 .c0 .c1 {
@@ -270,6 +272,7 @@ exports[`Button Group :  Button group with all ghost buttons : snapshot 1`] = `
 .c4:focus {
   color: #0066ff;
   background-color: #ffffff;
+  cursor: pointer;
 }
 
 .c4:hover svg path,
@@ -330,6 +333,7 @@ exports[`Button Group :  Button group with all ghost buttons : snapshot 1`] = `
 .c2:focus {
   color: #0066ff;
   background-color: #ffffff;
+  cursor: pointer;
 }
 
 .c2:hover svg path,
@@ -375,10 +379,10 @@ exports[`Button Group :  Button group with all ghost buttons : snapshot 1`] = `
 }
 
 .c0 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
 }
 
 .c0 .c1 {


### PR DESCRIPTION
 - adding style, classname & other props (like eventHandler) to div container of ButtonGroup

 - added proper types along with it

 - fix width of ButtonGroup div using `display: inline-flex` before it was taking availabe width in box.

 - updated snapshots accordingly & added a custom style, custom classname story