### PR TITLE
Label Passing Style/Classname to props

### DIFF
--- a/src/components/Label/Label.tsx
+++ b/src/components/Label/Label.tsx
@@ -176,7 +176,8 @@ const StyledDiv = styled.div<IStyledLabel>`
 `
 
 const StyledTextSpan = styled.span<IStyledLabel>`
-  margin: 0rem ${props => getTextRightMargin(props)} 0rem ${props => getTextLeftMargin(props)};
+  margin: 0rem ${props => getTextRightMargin(props)} 0rem
+    ${props => getTextLeftMargin(props)};
 `
 
 const Label: ILabel = props => {
@@ -195,19 +196,14 @@ const Label: ILabel = props => {
     rest.customColor = rest.customColor || INSET_BACKGROUND_COLOR
   }
 
-  const scProps = { className, style, theme, customProps: rest }
+  const scProps = { theme, customProps: rest }
 
   const renderLeftIcon = () => {
     if (!showLeftIcon(scProps)) {
       return null
     }
     if (_.isString(icons!.left)) {
-      return (
-        <Icon
-          fill={getFontColor(scProps)}
-          type={icons!.left}
-        />
-      )
+      return <Icon fill={getFontColor(scProps)} type={icons!.left} />
     }
     return icons!.left
   }
@@ -217,21 +213,20 @@ const Label: ILabel = props => {
       return null
     }
     if (_.isString(icons!.right)) {
-      return (
-        <Icon
-          fill={getFontColor(scProps)}
-          type={icons!.right}
-        />
-      )
+      return <Icon fill={getFontColor(scProps)} type={icons!.right} />
     }
     return icons!.right
   }
 
   //For styled components, we separate the props that are to be loaded on the DOM
   return (
-    <StyledDiv {...scProps} insetColor={insetColor}>
+    <StyledDiv
+      className={className}
+      style={style}
+      {...scProps}
+      insetColor={insetColor}>
       {renderLeftIcon()}
-      <StyledTextSpan {...scProps} >{text}</StyledTextSpan>
+      <StyledTextSpan {...scProps}>{text}</StyledTextSpan>
       {renderRightIcon()}
     </StyledDiv>
   )

--- a/src/components/Label/__tests__/__snapshots__/Label.test.tsx.snap
+++ b/src/components/Label/__tests__/__snapshots__/Label.test.tsx.snap
@@ -32,7 +32,7 @@ exports[`Label custom class 1`] = `
     class="custom-class c0"
   >
     <span
-      class="custom-class c1"
+      class="c1"
     >
       label
     </span>
@@ -114,7 +114,6 @@ exports[`Label custom style 1`] = `
   >
     <span
       class="c1"
-      style="background-color: red;"
     >
       label
     </span>


### PR DESCRIPTION
Due to recent changes Label, style & classname props are passed in child component `StyledTextSpan`, which should only be passed to parent or root of Component.