### PR TITLE
ButtonGroup API change

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "knit-ui",
-  "version": "0.4.9",
+  "version": "0.4.10",
   "description": "Component library for Clarisights",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -1,6 +1,6 @@
 import React from "react"
 import { storiesOf } from "@storybook/react"
-import { Button, ButtonGroup } from "./"
+import Button from "./"
 import {
   withKnobs,
   text,
@@ -209,7 +209,7 @@ stories
     const bare = boolean("bare", false)
 
     return (
-      <ButtonGroup>
+      <Button.Group>
         <Button
           label={text("Label 1", "")}
           type={type}
@@ -243,7 +243,7 @@ stories
           onClick={action("button-click 3")}
           icon={text("Icon 3", "oExpandMore")}
         />
-      </ButtonGroup>
+      </Button.Group>
     )
   })
   .add("Button Group Custom Style & Classname", () => {
@@ -268,7 +268,7 @@ stories
     const disabled = boolean("disabled", false)
     const bare = boolean("bare", false)
     return (
-      <ButtonGroup style={style} className={className}>
+      <Button.Group style={style} className={className}>
         <Button
           label={text("Label 2", "Dropdown")}
           type={type}
@@ -291,6 +291,6 @@ stories
           onClick={action("button-click 3")}
           icon={text("Icon 3", "oExpandMore")}
         />
-      </ButtonGroup>
+      </Button.Group>
     )
   })

--- a/src/components/Button/ButtonGroup.tsx
+++ b/src/components/Button/ButtonGroup.tsx
@@ -1,7 +1,7 @@
 import React, { ReactNode, ReactElement } from "react"
 import styled from "styled-components"
 import { ButtonBase } from "./components"
-import { BaseComponentProps } from "../../common/types"
+import { ButtonGroupProps } from "./types"
 
 const getStyleForGhostButtons = (props: ButtonGroupWrapperProps) => {
   const style = props.isAllGhost
@@ -63,19 +63,17 @@ const ButtonGroupWrapper = styled.div<ButtonGroupWrapperProps>`
   ${props => getStyleForGhostButtons(props)}
 `
 
-interface ButtonGroupProps extends BaseComponentProps {
-  children: ReactNode
-  [htmlProp: string]: any
-}
 const ButtonGroup: React.FC<ButtonGroupProps> = props => {
-  const childrenCount = React.Children.count(props.children)
   const { children, ...rest } = props
+
+  const childrenCount = React.Children.count(children)
   let countGhost = 0
-  React.Children.forEach(props.children, (child: ReactElement, i) => {
+  React.Children.forEach(children, (child: ReactElement, i) => {
     if (child.props.ghost) countGhost += 1
   })
 
   const isAllGhost = countGhost === childrenCount ? true : false
+
   return (
     <ButtonGroupWrapper isAllGhost={isAllGhost} {...rest}>
       {React.Children.map(props.children, (child: ReactElement, i: Number) =>

--- a/src/components/Button/ButtonWrapper.tsx
+++ b/src/components/Button/ButtonWrapper.tsx
@@ -3,11 +3,11 @@ import Icon from "../Icon"
 import { ButtonBase, ButtonInset } from "./components"
 import { ThemeContext } from "styled-components"
 import { parseCustomColor, parseColorPreset } from "../../common/_utils"
-import { ButtonWrapperProps } from "./types"
+import { ButtonWrapperInterface, ButtonWrapperProps } from "./types"
 
 const DEFAULT_COLOR_THEME = "neutral"
 
-const ButtonWrapper: React.FC<ButtonWrapperProps> = ({
+const ButtonWrapper: ButtonWrapperInterface<ButtonWrapperProps> = ({
   label,
   type = "primary",
   ghost = false,
@@ -89,4 +89,6 @@ const ButtonWrapper: React.FC<ButtonWrapperProps> = ({
   )
 }
 
+import ButtonGroup from "./ButtonGroup"
+ButtonWrapper.Group = ButtonGroup
 export default ButtonWrapper

--- a/src/components/Button/README.md
+++ b/src/components/Button/README.md
@@ -40,11 +40,11 @@ Button Group is container which have buttons as it's child and group them togeth
 ### Usage
 
 ```javascript
-import { ButtonGroup } from "KnitUI"
+import { Button } from "KnitUI"
 
-<ButtonGroup>
+<Button.Group>
   <Button icon="oInfo" />
   <Button label="Dropdown" />
   <Button icon="oExpandMore" />
-</ButtonGroup>)
+</Button.Group>)
 ```

--- a/src/components/Button/__tests__/Button.test.tsx
+++ b/src/components/Button/__tests__/Button.test.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { Button, ButtonGroup } from ".."
+import Button from "../"
 import { render, cleanup, fireEvent } from "react-testing-library"
 import { ThemeProvider } from "../../../common/styles"
 import "jest-styled-components"
@@ -177,11 +177,11 @@ describe("Button Group : ", () => {
   it("Button group : snapshot", () => {
     const { asFragment } = render(
       <ThemeProvider>
-        <ButtonGroup>
+        <Button.Group>
           <Button icon="oInfo" />
           <Button label="Dropdown" />
           <Button icon="oExpandMore" />
-        </ButtonGroup>
+        </Button.Group>
       </ThemeProvider>
     )
     expect(asFragment()).toMatchSnapshot()
@@ -189,11 +189,11 @@ describe("Button Group : ", () => {
   it("Button group with all ghost buttons : snapshot", () => {
     const { asFragment } = render(
       <ThemeProvider>
-        <ButtonGroup>
+        <Button.Group>
           <Button icon="oInfo" ghost />
           <Button label="Dropdown" ghost />
           <Button icon="oExpandMore" ghost />
-        </ButtonGroup>
+        </Button.Group>
       </ThemeProvider>
     )
     expect(asFragment()).toMatchSnapshot()

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -1,2 +1,2 @@
-export { default as Button } from "./ButtonWrapper"
-export { default as ButtonGroup } from "./ButtonGroup"
+import Button from "./ButtonWrapper"
+export default Button

--- a/src/components/Button/types.ts
+++ b/src/components/Button/types.ts
@@ -3,7 +3,7 @@ import {
   CustomColor,
   BaseComponentProps,
 } from "../../common/types"
-import { SyntheticEvent } from "react"
+import { SyntheticEvent, ReactNode } from "react"
 
 export interface ParsedColorTheme {
   background: any
@@ -50,4 +50,13 @@ export interface BaseButtonProps extends ButtonBaseProps {
   colorTheme: ParsedColorTheme
   fontSize: number
   lineHeight: number
+}
+
+export interface ButtonGroupProps extends BaseComponentProps {
+  children: ReactNode
+  [htmlProp: string]: any
+}
+
+export interface ButtonWrapperInterface<T> extends React.FC<T> {
+  Group: React.FunctionComponent<ButtonGroupProps>
 }

--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -1,5 +1,5 @@
 /// <reference types="styled-components/cssprop" />
-export { Button, ButtonGroup } from "./Button"
+export { default as Button } from "./Button"
 export { default as Modal } from "./Modal"
 export { default as Input } from "./Input"
 export { default as Switch } from "./Switch"


### PR DESCRIPTION
This change is required because currently using this library as external module,
with commonJs as modules type of `knit-ui` & `ES6 import type  with
babel` in user project giving error for some cases, only identify modules which
are exported as default in each index.js (or non-default, Not sure of the specific reason)
So Keeping only `Button` as default & `ButtonGroup` passing as `Button.Group` object property of Button.