### PR TITLE
addition of Alerts onExit props & autoDismiss clear setTimeoutInterval

### DIFF
--- a/src/components/Alerts/Alert.tsx
+++ b/src/components/Alerts/Alert.tsx
@@ -71,6 +71,9 @@ const renderActions = (scProps: IStyledAlert) => {
 const Alert: React.FC<AlertProps> = (props: AlertProps) => {
   const { className, ...rest } = props
 
+  // To clear autoDismiss setTimeoutInterval during unmount
+  let interval
+
   const scProps = { className, customProps: rest }
   const {
     image,
@@ -113,12 +116,13 @@ const Alert: React.FC<AlertProps> = (props: AlertProps) => {
 
     // When unmount onExit function will be called
     return () => {
+      interval && clearInterval(interval)
       onExit && onExit(alertKey!)
     }
   }, [])
 
   // To Auto dismiss the alert after some duration, can use transition delay check out again
-  if (autoDismiss) setTimeout(() => fadeAway(), dismissDuration)
+  if (autoDismiss) interval = setTimeout(() => fadeAway(), dismissDuration)
 
   // called by both AutoDismiss and Close Icon click
   const fadeAway = (event?: SyntheticEvent): void => {

--- a/src/components/Alerts/Alert.tsx
+++ b/src/components/Alerts/Alert.tsx
@@ -81,6 +81,8 @@ const Alert: React.FC<AlertProps> = (props: AlertProps) => {
     dismissDuration,
     actions,
     onClose,
+    onExit,
+    alertKey,
   } = rest
 
   const [open, setOpen] = useState(true)
@@ -107,6 +109,11 @@ const Alert: React.FC<AlertProps> = (props: AlertProps) => {
     // heading only exist if multiline prop is true
     if (heading && !multiLine) {
       console.error("Please pass multiLine prop to use headings")
+    }
+
+    // When unmount onExit function will be called
+    return () => {
+      onExit && onExit(alertKey!)
     }
   }, [])
 

--- a/src/components/Alerts/Alerts.README.md
+++ b/src/components/Alerts/Alerts.README.md
@@ -21,6 +21,7 @@ const Component = (props: any) => {
 
     const PopUpAlert = ():string => {
         let key = addAlert({
+            alertKey: "fc780390-235b-431f-8f29-53475a3747eb"
             type: "neutral",
             size: "medium",
             content: "Hello KnitUI",
@@ -33,6 +34,7 @@ const Component = (props: any) => {
             actions: [{text: "Action", callback: (key:string)=>alert('Action is called')}]
             onClose: ()=>{console.log('Alert is closed')},
             customColor: "#ff2d4e",
+            onExit: (key:string) => {...}
             // className: "my_class",
             // prefixClassName: "my_pop"
         })
@@ -86,6 +88,7 @@ import { Alert } from "KnitUI"
 
 | Prop name       | Type           | Default                                                        | Description                                                                                                                                                                                                                                   |
 | --------------- | -------------- | -------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| alertKey        | `string`       | Unique each time                                               | unique key should be passed if manually handling keys, else by default each time it generate unique key for each alert.                                                                                                                       |
 | type            | `alertType`    | `neutral | unsaved | warning | success | danger`               | Indicates type of the alert and set some default theme according to that.                                                                                                                                                                     |
 | size            | `sizeType`     | `x-small | small | medium | large`                             | Width of the alert message occupied on the screen                                                                                                                                                                                             |
 | content         | string         | -                                                              | Content of the Alert Component                                                                                                                                                                                                                |
@@ -96,7 +99,8 @@ import { Alert } from "KnitUI"
 | icon            | string         | -                                                              | icon type to be rendered in the alert                                                                                                                                                                                                         |
 | image           | string         | -                                                              | Image url to be shown as icon in alert                                                                                                                                                                                                        |
 | actions         | `actionType[]` | `type actionType = { text: string, callback: (key) => {...} }` | Array of actions will be shown on alert as buttons, alert's `key` is passed so user can remove alert from action.                                                                                                                             |
-| onClose         | Function       | None                                                           | A click handler to be executed on closing of the alert. Will receive the `event` as an argument                                                                                                                                               |
-| className       | string         | None                                                           | add class to main alert wrapper to provide custom class                                                                                                                                                                                       |
-| prefixClassName | string         | None                                                           | create set of classes which add to each part of alert with provided prefix, classes are -> -knit-alert, -knit-alert-icon, -knit-alert-close, -knit-alert-content, -knit-alert-action-wrapper, -knit-alert-action, -knit-alert-content-wrapper |
-| customColor     | string         | None                                                           | custom color to be in background, using chroma along with it get font or general color                                                                                                                                                        |
+| onClose         | Function       | -                                                              | A click handler to be executed on closing of the alert. Will receive the `event` as an argument                                                                                                                                               |
+| onExit          | Function       | -                                                              | This function will be executed when Alert component will unmount. Function have received the `key` as an argument.eg. `(key) => {...}`                                                                                                        |
+| className       | string         | -                                                              | add class to main alert wrapper to provide custom class                                                                                                                                                                                       |
+| prefixClassName | string         | -                                                              | create set of classes which add to each part of alert with provided prefix, classes are -> -knit-alert, -knit-alert-icon, -knit-alert-close, -knit-alert-content, -knit-alert-action-wrapper, -knit-alert-action, -knit-alert-content-wrapper |
+| customColor     | string         | -                                                              | custom color to be in background, using chroma along with it get font or general color                                                                                                                                                        |

--- a/src/components/Alerts/Alerts.stories.tsx
+++ b/src/components/Alerts/Alerts.stories.tsx
@@ -359,6 +359,35 @@ stories
     }
     return <AlertDismissComponent />
   })
+  .add("Exit Function when unmount", () => {
+    const AlertOnExitComponent = props => {
+      const { addAlert, removeAlert } = useAlerts()
+
+      const handleClick = () =>
+        addAlert({
+          type: "warning",
+          size: "small",
+          placement: "topRight",
+          autoDismiss: false,
+          dismissDuration: 1500,
+          heading: "Hi there", // only uncomment when multiLine props is true else throw an error, as suppose to
+          multiLine: true,
+          actions: alertActions,
+          content: "Normal Content",
+          icon: "",
+          onClose: () => {},
+          onExit: key =>
+            alert(`onExit function is called of alert which have key : ${key}`),
+        })
+
+      return (
+        <Center>
+          <Button onClick={handleClick} label="Show Alert" />
+        </Center>
+      )
+    }
+    return <AlertOnExitComponent />
+  })
   .add("Custom Color Alert", () => (
     <Alert
       image="https://clarisights-users.s3.eu-central-1.amazonaws.com/production/users/profile_picture_561/1540893983_clarisights.png"

--- a/src/components/Alerts/__test__/Alerts.test.tsx
+++ b/src/components/Alerts/__test__/Alerts.test.tsx
@@ -172,6 +172,15 @@ describe("Alert Component Tests", () => {
 
     expect(alertComponent).toHaveClass("hide")
   })
+
+  test("onExit is called when alert unmount", async () => {
+    const onExitFn = jest.fn()
+    const { unmount } = renderComponent(
+      <Alert content="Hello there" onExit={onExitFn} />
+    )
+    unmount()
+    expect(onExitFn).toHaveBeenCalledTimes(1)
+  })
 })
 
 //** Alert Placement Wrapper and placement test **//

--- a/src/components/Alerts/types.ts
+++ b/src/components/Alerts/types.ts
@@ -46,6 +46,8 @@ export interface AlertProps {
   actions?: Array<actionType>
   // Function to call once the alert is closed
   onClose?: (event) => void
+  // Function to call while alert is unmounted
+  onExit?: (key: string) => void
   // position on window where it will be displayed
   placement?: placementType
   // key to reference Element from Alerts Container (help in remove function)


### PR DESCRIPTION
-  Alert onExit when unmount    
     - Add a props to alert component, `onExit`, a callback function which will be called when Alert component will unmount
     - Add test cases for corresponding changes
     - Edit readme for corresponding changes
- clear autoDismiss setTimeoutInterval when unmount
