### PR TITLE
Alert onClose takes key instead of event as a parameter

### DIFF
--- a/src/components/Alerts/Alert.tsx
+++ b/src/components/Alerts/Alert.tsx
@@ -126,7 +126,9 @@ const Alert: React.FC<AlertProps> = (props: AlertProps) => {
 
   // called by both AutoDismiss and Close Icon click
   const fadeAway = (event?: SyntheticEvent): void => {
-    onClose && onClose(event)
+    if (onClose) {
+      onClose(alertKey)
+    }
     setOpen(false)
   }
 

--- a/src/components/Alerts/Alerts.README.md
+++ b/src/components/Alerts/Alerts.README.md
@@ -30,9 +30,9 @@ const Component = (props: any) => {
             dismissDuration: "500",
             heading: "Heading will be here",
             multiLine: "true",
-            icon: "",
+            icon: "", 
             actions: [{text: "Action", callback: (key:string)=>alert('Action is called')}]
-            onClose: ()=>{console.log('Alert is closed')},
+            onClose: (key) => { console.log(`Alert ${key} is closed`)},
             customColor: "#ff2d4e",
             onExit: (key:string) => {...}
             // className: "my_class",
@@ -99,7 +99,7 @@ import { Alert } from "KnitUI"
 | icon            | string         | -                                                              | icon type to be rendered in the alert                                                                                                                                                                                                         |
 | image           | string         | -                                                              | Image url to be shown as icon in alert                                                                                                                                                                                                        |
 | actions         | `actionType[]` | `type actionType = { text: string, callback: (key) => {...} }` | Array of actions will be shown on alert as buttons, alert's `key` is passed so user can remove alert from action.                                                                                                                             |
-| onClose         | Function       | -                                                              | A click handler to be executed on closing of the alert. Will receive the `event` as an argument                                                                                                                                               |
+| onClose         | (key: string) = void      | -                                                              | A click handler to be executed on closing of the alert. Will receive the `key` of the alert as an argument                                                                                                                                               |
 | onExit          | Function       | -                                                              | This function will be executed when Alert component will unmount. Function have received the `key` as an argument.eg. `(key) => {...}`                                                                                                        |
 | className       | string         | -                                                              | add class to main alert wrapper to provide custom class                                                                                                                                                                                       |
 | prefixClassName | string         | -                                                              | create set of classes which add to each part of alert with provided prefix, classes are -> -knit-alert, -knit-alert-icon, -knit-alert-close, -knit-alert-content, -knit-alert-action-wrapper, -knit-alert-action, -knit-alert-content-wrapper |

--- a/src/components/Alerts/AlertsProvider.tsx
+++ b/src/components/Alerts/AlertsProvider.tsx
@@ -46,8 +46,10 @@ class AlertsProvider extends React.Component<{}, AlertsProviderState> {
 
     // Closing Alert will call remove method of this class to update state
     const curOnClose = alertProps.onClose
-    alertProps.onClose = event => {
-      curOnClose && curOnClose(event)
+    alertProps.onClose = key => {
+      if (curOnClose) {
+        curOnClose(key)
+      }
       this.handleRemove(alertProps.alertKey!)
     }
     this.queue.push(alertProps)

--- a/src/components/Alerts/__test__/Alerts.test.tsx
+++ b/src/components/Alerts/__test__/Alerts.test.tsx
@@ -151,13 +151,14 @@ describe("Alert Component Tests", () => {
     const onCloseFn = jest.fn()
 
     const { getByTestId, container } = renderComponent(
-      <Alert content="Hello there" onClose={onCloseFn} />
+      <Alert alertKey="my-alert-key" content="Hello there" onClose={onCloseFn} />
     )
 
     const closeButton = container.querySelector(`button`)
     // const closeButton = getByTestId("alert-close")
     fireEvent.click(closeButton!)
     expect(onCloseFn).toBeCalledTimes(1)
+    expect(onCloseFn).toBeCalledWith("my-alert-key")
     expect(container).toHaveTextContent("Hello there")
   })
 


### PR DESCRIPTION
`key` may be required in `onClose` if some actions have to be onClose that require the key.
Removing event because it is not useful in this case. If we do find that both are needed we can have two params being passes instead.