### PR TITLE
Support types for HTML attributes to be passed in buttons

### DIFF
--- a/src/common/styles/__test__/ThemeProvider.test.tsx
+++ b/src/common/styles/__test__/ThemeProvider.test.tsx
@@ -7,7 +7,7 @@ import { Button } from "../../.."
 
 describe("Passing Custom Theme", () => {
   // Changing one of the palette color
-  let newPalette = {
+  const newPalette = {
     ...palette,
     Blue100: {
       hsl: [205, 85, 45],

--- a/src/common/styles/__test__/ThemeProvider.test.tsx
+++ b/src/common/styles/__test__/ThemeProvider.test.tsx
@@ -20,7 +20,7 @@ describe("Passing Custom Theme", () => {
   it("Changing palette color Blue100 to #1182D4", () => {
     const { asFragment } = render(
       <ThemeProvider theme={knituiTheme}>
-        <Button type="primary" size="small" label="Changed Color of Neutral" />
+        <Button kind="primary" size="small" label="Changed Color of Neutral" />
       </ThemeProvider>
     )
     expect(asFragment()).toMatchSnapshot()

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -15,7 +15,7 @@ const Readme = require("./README.md")
 const stories = storiesOf("Buttons", module)
 stories.addDecorator(withKnobs)
 
-const typeOptions = {
+const kindOptions = {
   Primary: "primary",
   Secondary: "secondary",
 }
@@ -45,7 +45,7 @@ stories
   .add("Simple primary with text", () => (
     <Button
       label={text("Label", "Button")}
-      type={select("Type", typeOptions, "primary")}
+      kind={select("Kind", kindOptions, "primary")}
       size={select("Size", sizeOptions, "medium")}
       colorPreset={select("Color preset", colorThemeOptions, "neutral")}
       ghost={boolean("Ghost", false)}
@@ -57,7 +57,7 @@ stories
   .add("With a non-default color preset", () => (
     <Button
       label={text("Label", "Button")}
-      type={select("Type", typeOptions, "primary")}
+      kind={select("Kind", kindOptions, "primary")}
       size={select("Size", sizeOptions, "medium")}
       colorPreset={select("Color preset", colorThemeOptions, "danger")}
       ghost={boolean("Ghost", false)}
@@ -69,7 +69,7 @@ stories
   .add("Simple secondary with text", () => (
     <Button
       label={text("Label", "Button")}
-      type={select("Type", typeOptions, "secondary")}
+      type={select("Type", kindOptions, "secondary")}
       size={select("Size", sizeOptions, "medium")}
       colorPreset={select("Color preset", colorThemeOptions, "neutral")}
       ghost={boolean("Ghost", false)}
@@ -81,7 +81,7 @@ stories
   .add("Ghost (inverted color scheme)", () => (
     <Button
       label={text("Label", "Button")}
-      type={select("Type", typeOptions, "primary")}
+      kind={select("Kind", kindOptions, "primary")}
       size={select("Size", sizeOptions, "medium")}
       colorPreset={select("Color preset", colorThemeOptions, "neutral")}
       ghost={boolean("Ghost", true)}
@@ -93,7 +93,7 @@ stories
   .add("With an inset", () => (
     <Button
       label={text("Label", "Button")}
-      type={select("Type", typeOptions, "primary")}
+      kind={select("Kind", kindOptions, "primary")}
       size={select("Size", sizeOptions, "medium")}
       colorPreset={select("Color preset", colorThemeOptions, "neutral")}
       ghost={boolean("Ghost", false)}
@@ -195,7 +195,7 @@ stories
   ))
   .add("Button Group", () => {
     // props which should be same for all Buttons in ButtonGroup
-    const type = options("type", typeOptions, "primary", {
+    const type = options("type", kindOptions, "primary", {
       display: "inline-radio",
     })
     const size = options("size", sizeOptions, "medium", {
@@ -255,7 +255,7 @@ stories
     const className = text("text", "HelloGroup")
 
     // props which should be same for all Buttons in ButtonGroup
-    const type = options("type", typeOptions, "primary", {
+    const type = options("type", kindOptions, "primary", {
       display: "inline-radio",
     })
     const size = options("size", sizeOptions, "medium", {
@@ -303,7 +303,7 @@ stories
     const className = text("text", "HelloGroup")
 
     // props which should be same for all Buttons in ButtonGroup
-    const type = options("type", typeOptions, "primary", {
+    const type = options("type", kindOptions, "primary", {
       display: "inline-radio",
     })
     const size = options("size", sizeOptions, "medium", {

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -33,6 +33,24 @@ const colorThemeOptions = {
   Unsaved: "unsaved",
 }
 
+const defaultProps = {
+  label: text("Label", "Button"),
+  kind: select("Kind", kindOptions, "primary"),
+  size: select("Size", sizeOptions, "medium"),
+  ghost: boolean("Ghost", false),
+  disabled: boolean("Disabled", false),
+  bare: boolean("Bare", false),
+  onClick: action("button-click"),
+  colorPreset: select("Color preset", colorThemeOptions, "neutral")
+}
+
+const additionalProps = {
+  icon: text("Icon", "oInfo"),
+  insetLabel: text("InsetLabel", "10"),
+  customColor: text("Custom Color", "#9242f4"),
+  insetCustomColor: text("Inset Custom Color", "#000000")
+}
+
 stories
   .addParameters({
     readme: {
@@ -44,158 +62,86 @@ stories
   })
   .add("Simple primary with text", () => (
     <Button
-      label={text("Label", "Button")}
-      kind={select("Kind", kindOptions, "primary")}
-      size={select("Size", sizeOptions, "medium")}
-      colorPreset={select("Color preset", colorThemeOptions, "neutral")}
-      ghost={boolean("Ghost", false)}
-      disabled={boolean("Disabled", false)}
-      bare={boolean("Bare", false)}
-      onClick={action("button-click")}
+      {...defaultProps}
     />
   ))
   .add("With a non-default color preset", () => (
     <Button
-      label={text("Label", "Button")}
-      kind={select("Kind", kindOptions, "primary")}
-      size={select("Size", sizeOptions, "medium")}
+      {...defaultProps}
       colorPreset={select("Color preset", colorThemeOptions, "danger")}
-      ghost={boolean("Ghost", false)}
-      disabled={boolean("Disabled", false)}
-      bare={boolean("Bare", false)}
-      onClick={action("button-click")}
     />
   ))
   .add("Simple secondary with text", () => (
     <Button
-      label={text("Label", "Button")}
-      type={select("Type", kindOptions, "secondary")}
-      size={select("Size", sizeOptions, "medium")}
-      colorPreset={select("Color preset", colorThemeOptions, "neutral")}
-      ghost={boolean("Ghost", false)}
-      disabled={boolean("Disabled", false)}
-      bare={boolean("Bare", false)}
-      onClick={action("button-click")}
+      {...defaultProps}
+      kind={select("Kind", kindOptions, "secondary")}
     />
   ))
   .add("Ghost (inverted color scheme)", () => (
     <Button
-      label={text("Label", "Button")}
-      kind={select("Kind", kindOptions, "primary")}
-      size={select("Size", sizeOptions, "medium")}
-      colorPreset={select("Color preset", colorThemeOptions, "neutral")}
+      {...defaultProps}
       ghost={boolean("Ghost", true)}
-      disabled={boolean("Disabled", false)}
-      bare={boolean("Bare", false)}
-      onClick={action("button-click")}
     />
   ))
   .add("With an inset", () => (
     <Button
-      label={text("Label", "Button")}
-      kind={select("Kind", kindOptions, "primary")}
-      size={select("Size", sizeOptions, "medium")}
-      colorPreset={select("Color preset", colorThemeOptions, "neutral")}
-      ghost={boolean("Ghost", false)}
-      disabled={boolean("Disabled", false)}
-      insetLabel={text("InsetLabel", "10")}
-      onClick={action("button-click")}
+      {...defaultProps}
+      insetLabel={additionalProps.insetLabel}
     />
   ))
   .add("Icon", () => (
     <Button
-      icon={text("Icon", "oInfo")}
-      size={select("Size", sizeOptions, "medium")}
-      colorPreset={select("Color preset", colorThemeOptions, "neutral")}
-      ghost={boolean("Ghost", false)}
-      disabled={boolean("Disabled", false)}
-      bare={boolean("Bare", false)}
-      onClick={action("button-click")}
+      {...defaultProps}
+      label={undefined}
+      icon={additionalProps.icon}
     />
   ))
   .add("Icon with text", () => (
     <Button
-      icon={text("Icon", "oInfo")}
-      label={text("Label", "Button")}
-      size={select("Size", sizeOptions, "medium")}
-      colorPreset={select("Color preset", colorThemeOptions, "neutral")}
-      ghost={boolean("Ghost", false)}
-      disabled={boolean("Disabled", false)}
-      bare={boolean("Bare", false)}
-      onClick={action("button-click")}
+      {...defaultProps}
+      icon={additionalProps.icon}
     />
   ))
   .add("Icon with text and an inset", () => (
     <Button
-      icon={text("Icon", "oInfo")}
-      label={text("Label", "Button")}
-      size={select("Size", sizeOptions, "medium")}
-      colorPreset={select("Color preset", colorThemeOptions, "neutral")}
-      ghost={boolean("Ghost", false)}
-      disabled={boolean("Disabled", false)}
-      bare={boolean("Bare", false)}
-      insetLabel={text("InsetLabel", "10")}
-      onClick={action("button-click")}
+      {...defaultProps}
+      icon={additionalProps.icon}
+      insetLabel={additionalProps.insetLabel}
     />
   ))
   .add("With a custom color scheme", () => (
     <Button
-      icon={text("Icon", "oInfo")}
-      label={text("Label", "Button")}
-      size={select("Size", sizeOptions, "medium")}
-      disabled={boolean("Disabled", false)}
-      bare={boolean("Bare", false)}
-      onClick={action("button-click")}
-      insetLabel={text("InsetLabel", "10")}
-      customColor={text("Custom Color", "#9242f4")}
-      insetCustomColor={text("Custom Color", "#000000")}
-      ghost={boolean("Ghost", false)}
+      {...defaultProps}
+      icon={additionalProps.icon}
+      insetLabel={additionalProps.insetLabel}
+      customColor={additionalProps.customColor}
+      insetCustomColor={additionalProps.insetCustomColor}
     />
   ))
   .add("With a custom color object scheme", () => (
     <Button
-      icon={text("Icon", "oInfo")}
-      label={text("Label", "Button")}
-      size={select("Size", sizeOptions, "medium")}
-      disabled={boolean("Disabled", false)}
-      bare={boolean("Bare", false)}
-      onClick={action("button-click")}
-      insetLabel={text("InsetLabel", "10")}
+      {...defaultProps}
       customColor={object("Custom Color", {
         color: "#939323",
         secondaryColor: "#800204",
       })}
-      insetCustomColor={text("Custom Color", "#000000")}
-      ghost={boolean("Ghost", false)}
     />
   ))
   .add("With an href", () => (
     <Button
-      icon={text("Icon", "oInfo")}
-      label={text("Label", "Button")}
-      size={select("Size", sizeOptions, "medium")}
-      colorPreset={select("Color preset", colorThemeOptions, "neutral")}
-      ghost={boolean("Ghost", false)}
-      disabled={boolean("Disabled", false)}
-      bare={boolean("Bare", false)}
-      insetLabel={text("InsetLabel", "10")}
+      {...defaultProps}
       href="/sample"
     />
   ))
   .add("With custom styles", () => (
     <Button
-      label={text("Label", "Button")}
-      size={select("Size", sizeOptions, "medium")}
-      colorPreset={select("Color preset", colorThemeOptions, "neutral")}
-      ghost={boolean("Ghost", false)}
-      disabled={boolean("Disabled", false)}
-      bare={boolean("Bare", false)}
+      {...defaultProps}
       style={object("Style", { backgroundColor: "red" })}
     />
   ))
   .add("Button Group", () => {
     // props which should be same for all Buttons in ButtonGroup
-    const type = options("type", kindOptions, "primary", {
+    const kind = options("kind", kindOptions, "primary", {
       display: "inline-radio",
     })
     const size = options("size", sizeOptions, "medium", {
@@ -212,7 +158,7 @@ stories
       <Button.Group>
         <Button
           label={text("Label 1", "")}
-          type={type}
+          kind={kind}
           size={size}
           colorPreset={colorPreset}
           ghost={ghost}
@@ -223,7 +169,7 @@ stories
         />
         <Button
           label={text("Label 2", "Dropdown")}
-          type={type}
+          kind={kind}
           size={size}
           colorPreset={colorPreset}
           ghost={ghost}
@@ -234,7 +180,7 @@ stories
         />
         <Button
           label={text("Label 3", "")}
-          type={type}
+          kind={kind}
           size={size}
           colorPreset={colorPreset}
           ghost={ghost}
@@ -255,7 +201,7 @@ stories
     const className = text("text", "HelloGroup")
 
     // props which should be same for all Buttons in ButtonGroup
-    const type = options("type", kindOptions, "primary", {
+    const kind = options("kind", kindOptions, "primary", {
       display: "inline-radio",
     })
     const size = options("size", sizeOptions, "medium", {
@@ -271,7 +217,7 @@ stories
       <Button.Group style={style} className={className}>
         <Button
           label={text("Label 2", "Dropdown")}
-          type={type}
+          kind={kind}
           size={size}
           colorPreset={colorPreset}
           ghost={ghost}
@@ -282,7 +228,7 @@ stories
         />
         <Button
           label={text("Label 3", "")}
-          type={type}
+          kind={kind}
           size={size}
           colorPreset={colorPreset}
           ghost={ghost}
@@ -303,7 +249,7 @@ stories
     const className = text("text", "HelloGroup")
 
     // props which should be same for all Buttons in ButtonGroup
-    const type = options("type", kindOptions, "primary", {
+    const kind = options("kind", kindOptions, "primary", {
       display: "inline-radio",
     })
     const size = options("size", sizeOptions, "medium", {
@@ -319,7 +265,7 @@ stories
       <Button.Group style={style} className={className}>
         <Button
           label={text("Label 2", "Dropdown")}
-          type={type}
+          kind={kind}
           size={size}
           colorPreset={colorPreset}
           ghost={ghost}
@@ -330,7 +276,7 @@ stories
         />
         <Button
           label={text("Label 3", "")}
-          type={type}
+          kind={kind}
           size={size}
           colorPreset={colorPreset}
           ghost={ghost}

--- a/src/components/Button/ButtonWrapper.tsx
+++ b/src/components/Button/ButtonWrapper.tsx
@@ -9,10 +9,9 @@ const DEFAULT_COLOR_THEME = "neutral"
 
 const ButtonWrapper: ButtonWrapperInterface<ButtonWrapperProps> = ({
   label,
-  type = "primary",
+  kind = "primary",
   ghost = false,
   size = "medium",
-  disabled = false,
   href,
   onClick,
   icon,
@@ -21,8 +20,6 @@ const ButtonWrapper: ButtonWrapperInterface<ButtonWrapperProps> = ({
   colorPreset = DEFAULT_COLOR_THEME,
   customColor,
   insetCustomColor,
-  className,
-  style,
   customProps /** (define just to exclude from rest) In case Button is wrapped in StyledComponent with customProps passed down to manipulate style, 
   like when Button is used in other components. eg. Alerts, yet no need in Button Component itself*/,
   ...rest
@@ -61,11 +58,10 @@ const ButtonWrapper: ButtonWrapperInterface<ButtonWrapperProps> = ({
       customProps={{
         label,
         icon,
-        type,
+        kind,
         ghost,
         size,
         bare,
-        disabled,
         colorTheme: parsedColorTheme,
         fontSize: baseFontSize,
         lineHeight: baseLineHeight,
@@ -73,9 +69,6 @@ const ButtonWrapper: ButtonWrapperInterface<ButtonWrapperProps> = ({
       onClick={(e: SyntheticEvent) =>
         (onClick && onClick(e)) || (href && window.location.assign(href))
       }
-      disabled={disabled}
-      className={className}
-      style={style}
       {...rest}>
       {icon ? <Icon type={icon} size={iconSize} /> : null}
       {label}

--- a/src/components/Button/README.md
+++ b/src/components/Button/README.md
@@ -7,7 +7,7 @@ import { Button } from "KnitUI"
 
 <Button
   label="Primary"
-  type="primary"
+  kind="primary"
 />)
 ```
 
@@ -16,7 +16,7 @@ import { Button } from "KnitUI"
 | Prop name        | Type                                                                  | Optional | Default   | Description                                                                                                                             |
 | ---------------- | --------------------------------------------------------------------- | -------- | --------- | --------------------------------------------------------------------------------------------------------------------------------------- |
 | label            | string                                                                | Yes      | None      | The text label to be shown on the button                                                                                                |
-| type             | `primary` or `secondary`                                              | Yes      | `primary` | Indicates the importance of the button's actions                                                                                        |
+| kind             | `primary` or `secondary`                                              | Yes      | `primary` | Indicates the importance of the button's actions                                                                                        |
 | colorPreset      | string, one of `neutral`, `danger`, `success`, `warning` or `unsaved` | Yes      | `neutral` | One of a set of predefined values that are representative of the type of action                                                         |
 | customColor      | `string` or `object`                                                  | Yes      | None      | A valid CSS color string or `{ color: CSSColorString, secondaryColor: CSSColorString }` object that overrides the default color presets |
 | insetCustomColor | string                                                                | Yes      | `white`   | Override defaults, should be valid CSS string                                                                                           |
@@ -35,7 +35,7 @@ import { Button } from "KnitUI"
 
 Button Group is container which have buttons as it's child and group them together for specific style.
 
-> **_Note:_** Button Group apply largest button's height to all buttons & consider ideal case that all button's are of default type or ghost, not mix of both of them, it works fine with having mix type but separator may have different width than in ideal case
+> **_Note:_** Button Group apply largest button's height to all buttons & consider ideal case that all button's are of default kind or ghost, not mix of both of them, it works fine with having mix kind but separator may have different width than in ideal case
 
 ### Usage
 

--- a/src/components/Button/__tests__/Button.test.tsx
+++ b/src/components/Button/__tests__/Button.test.tsx
@@ -25,7 +25,7 @@ describe("Button", () => {
       it("renders a primary variant with a label correctly", () => {
         const { asFragment } = render(
           <ThemeProvider>
-            <Button label="button" size={size} type="secondary" />
+            <Button label="button" size={size} kind="secondary" />
           </ThemeProvider>
         )
         expect(asFragment()).toMatchSnapshot()
@@ -134,7 +134,7 @@ describe("Button", () => {
   it("Should disable button rendered correctly", () => {
     const { asFragment } = render(
       <ThemeProvider>
-        <Button label="button" disabled={true} />
+        <Button label="button" disabled />
       </ThemeProvider>
     )
     expect(asFragment()).toMatchSnapshot()

--- a/src/components/Button/components/ButtonBase.tsx
+++ b/src/components/Button/components/ButtonBase.tsx
@@ -1,35 +1,11 @@
 import styled, { css } from "styled-components"
 import { IStyled } from "../../../common/types"
-import { SyntheticEvent } from "react"
 import { isLightColor } from "../../../common/_utils"
+import { ButtonProps } from "../types"
 
 type ButtonState = "default" | "hover" | "active" | "focus" | "disabled"
 
-interface ParsedColorTheme {
-  background: any
-  font: any
-  insetBackground?: any
-  insetFont?: any
-}
-
-interface BaseButtonProps {
-  label?: string
-  type: "primary" | "secondary"
-  colorTheme: ParsedColorTheme
-  ghost: boolean
-  size: "small" | "medium" | "large"
-  disabled?: boolean
-  bare: boolean
-  icon?: string
-  insetLabel?: string
-  onClick?: (event: SyntheticEvent) => void
-  fontSize: number
-  lineHeight: number
-  className: string
-  style: string
-}
-
-type IStyledBaseButton = IStyled<BaseButtonProps>
+type IStyledBaseButton = IStyled<ButtonProps>
 // Paddings
 
 const ICON_PADDINGS = {
@@ -46,7 +22,7 @@ const VERTICAL_PADINGS = {
 
 const getHorizontalPadding = (props: IStyledBaseButton) => {
   const {
-    customProps: { size, type, fontSize },
+    customProps: { size, kind, fontSize },
   } = props
   const paddings = {
     small: {
@@ -62,7 +38,7 @@ const getHorizontalPadding = (props: IStyledBaseButton) => {
       secondary: fontSize / 2,
     },
   }
-  return paddings[size][type]
+  return paddings[size!][kind!]
 }
 
 const getRightPadding = (props: IStyledBaseButton) => {
@@ -238,7 +214,7 @@ const StyledButton = styled.button<IStyledBaseButton>`
       :hover,
       :active,
       :focus {
-        color: ${(props: IStyled<BaseButtonProps>) =>
+        color: ${(props: IStyled<ButtonProps>) =>
           getFontColor("hover", props)};
         background-color: ${props => getBackgroundColor("hover", props)};
         svg path {

--- a/src/components/Button/types.ts
+++ b/src/components/Button/types.ts
@@ -1,7 +1,7 @@
 import {
   ColorPreset,
   CustomColor,
-  BaseComponentProps,
+  BaseComponentProps
 } from "../../common/types"
 import { SyntheticEvent, ReactNode } from "react"
 
@@ -12,11 +12,11 @@ export interface ParsedColorTheme {
   insetFont?: any
 }
 
-export interface ButtonBaseProps extends BaseComponentProps {
+export interface ButtonBaseProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   /** The text label to be shown on the button */
   label?: string
   /** Indicates the importance of the button's actions */
-  type?: "primary" | "secondary"
+  kind?: "primary" | "secondary"
   /**
    * One of a set of predefined values that are representative of
    * the type of action
@@ -24,8 +24,6 @@ export interface ButtonBaseProps extends BaseComponentProps {
   ghost?: boolean
   /** Physical area occupied on the screen */
   size?: "small" | "medium" | "large"
-  /** Whether the button should be disabled */
-  disabled?: boolean
   /** Only text/icon stripping the background */
   bare?: boolean
   /** An icon type to be rendered in the button */
@@ -48,7 +46,7 @@ export interface ButtonWrapperProps extends ButtonBaseProps {
   customProps?: any
 }
 
-export interface BaseButtonProps extends ButtonBaseProps {
+export interface ButtonProps extends ButtonBaseProps {
   colorTheme: ParsedColorTheme
   fontSize: number
   lineHeight: number


### PR DESCRIPTION
* Updates the types to support standard HTML button attributes
* Renmaes `type` to `kind` to avoid conflict with the standard HTML attribute of the same name.