### PR TITLE
refactor: simplify the way we consume props in styled components

### DIFF
--- a/src/common/styles/__test__/__snapshots__/ThemeProvider.test.tsx.snap
+++ b/src/common/styles/__test__/__snapshots__/ThemeProvider.test.tsx.snap
@@ -33,29 +33,12 @@ exports[`Passing Custom Theme Changing palette color Blue100 to #1182D4 1`] = `
   fill: #ffffff;
 }
 
-.c0:hover,
-.c0:active,
-.c0:focus {
-  color: #ffffff;
-  background-color: #2a9dee;
-  cursor: pointer;
-}
-
-.c0:hover svg path,
-.c0:active svg path,
-.c0:focus svg path {
-  fill: #ffffff;
-}
-
-.c0:active,
-.c0:focus {
-  border: 1px solid #5ab2f2 !important;
-  box-shadow: 0px 0px 2px #0066ff;
-  outline: none;
-}
-
-.c0:hover {
-  border: 1px solid #00000000;
+.c0 function (_a) {
+  -webkit-var: disabled = _a.disabled;
+  -moz-var: disabled = _a.disabled;
+  -ms-var: disabled = _a.disabled;
+  var: disabled = _a.disabled;
+  return: !disabled && styled_components_1.css(templateObject_1 || (templateObject_1 = __makeTemplateObject(["\\n      :hover,\\n      :active,\\n      :focus {\\n        color: ",";\\n        background-color: ",";\\n        svg path {\\n          fill: ",";\\n        }\\n        cursor: pointer;\\n      }\\n      :active,\\n      :focus {\\n        border: "," !important;\\n        box-shadow: ",";\\n        outline: none;\\n      }\\n      :hover {\\n        border: ",";\\n      }\\n    "],["\\n      :hover,\\n      :active,\\n      :focus {\\n        color: ",";\\n        background-color: ",";\\n        svg path {\\n          fill: ",";\\n        }\\n        cursor: pointer;\\n      }\\n      :active,\\n      :focus {\\n        border: "," !important;\\n        box-shadow: ",";\\n        outline: none;\\n      }\\n      :hover {\\n        border: ",";\\n      }\\n    "])),getFontColor("hover",props),getBackgroundColor("hover",props),getFontColor("hover",props),getBorder("active",props),getBoxShadow(props),getBorder("hover",props));
 }
 
 .c0:disabled {

--- a/src/components/Alerts/Alert.tsx
+++ b/src/components/Alerts/Alert.tsx
@@ -1,17 +1,17 @@
-import React, { useState, useEffect, SyntheticEvent } from "react"
-import { AlertProps } from "./types"
+import React, { SyntheticEvent, useEffect, useState } from "react"
+import { IStyled } from "../../common/types"
 import {
+  AlertActionsWrapper,
   AlertContainer,
   AlertContent,
-  StyledAlertIcon,
-  AlertHeading,
   AlertContentWrapper,
-  StyledAlertPicture,
-  StyledAlertAction,
-  AlertActionsWrapper,
+  AlertHeading,
   CloseIcon,
+  StyledAlertAction,
+  StyledAlertIcon,
+  StyledAlertPicture,
 } from "./StyledAlert"
-import { IStyled } from "../../common/types"
+import { AlertProps } from "./types"
 
 type IStyledAlert = IStyled<AlertProps>
 

--- a/src/components/Alerts/AlertsProvider.tsx
+++ b/src/components/Alerts/AlertsProvider.tsx
@@ -1,14 +1,14 @@
 import React from "react"
 import { v4 as uuid } from "uuid"
 import AlertContext from "./AlertContext"
-import TransitionWrapper from "./TransitionWrapper"
 import {
-  TopLeftBox,
-  TopRightBox,
   BottomLeftBox,
   BottomRightBox,
+  TopLeftBox,
+  TopRightBox,
 } from "./StyledAlerts"
-import { AlertProps, placementType, AlertsProviderState } from "./types"
+import TransitionWrapper from "./TransitionWrapper"
+import { AlertProps, AlertsProviderState, placementType } from "./types"
 
 const PlacementWrapperDiv = {
   topLeft: TopLeftBox,
@@ -35,7 +35,7 @@ class AlertsProvider extends React.Component<{}, AlertsProviderState> {
   handleAdd = (alertProps: AlertProps): string => {
     alertProps.placement =
       alertProps.placement || ("bottomLeft" as placementType)
-    
+
     // If the key is not provided, generate a new random key.
     alertProps.alertKey = alertProps.alertKey || uuid()
 
@@ -108,7 +108,10 @@ class AlertsProvider extends React.Component<{}, AlertsProviderState> {
           {Object.entries(alertsByPlace).map(([placement, alertArr]) => {
             const Wrapper = PlacementWrapperDiv[placement]
             return (
-              <Wrapper key={placement} data-testid="alerts-wrapper" className="alerts-wrapper" >
+              <Wrapper
+                key={placement}
+                data-testid="alerts-wrapper"
+                className="alerts-wrapper">
                 <TransitionWrapper alerts={alertArr!} />
               </Wrapper>
             )

--- a/src/components/Alerts/StyledAlert.tsx
+++ b/src/components/Alerts/StyledAlert.tsx
@@ -121,30 +121,26 @@ const getActionWrapperMargin = (props: IStyledAlert) => {
   return `${multiLine ? "1.4rem" : `0`} 0 0 0}`
 }
 
-export const AlertContainer = styled("div")<IStyledAlert>(
-  props => `
+export const AlertContainer = styled("div")(
+  (props: IStyledAlert) => `
   display: flex;
   box-sizing: border-box;
   overflow: hidden;
-
   width: ${getWidth(props)}rem;
   border-radius: ${getBorderRadius(props)};
   padding: 1.4rem;
-
   color: ${getFontColor(props)};
   background: ${getBackgroundColor(props)};
-
   opacity: 1;
   transition: all 0.25s;
-
   &.hide {
     opacity: 0;
   }
 `
 )
 
-export const AlertContentWrapper = styled.div<IStyledAlert>(
-  props => `
+export const AlertContentWrapper = styled.div(
+  (props: IStyledAlert) => `
   display: flex;
   width: 100%;
   flex-direction: ${getContentWrapperDirection(props)};
@@ -153,8 +149,8 @@ export const AlertContentWrapper = styled.div<IStyledAlert>(
 `
 )
 
-export const AlertContent = styled.div<IStyledAlert>(
-  props => `
+export const AlertContent = styled.div(
+  (props: IStyledAlert) => `
   font-size: ${getFontSize(props)}rem};
   line-height: ${getLineHeight(props)}rem};
   color: ${getFontColor(props)};
@@ -165,8 +161,8 @@ export const StyledAlertIcon = styled(Icon).attrs(props => ({
   fill: getFontColor(props),
   width: "2rem",
   height: "2rem",
-}))<IStyledAlert>(
-  props => `
+}))(
+  (props: IStyledAlert) => `
   align-self: ${getIconVerticalAlign(props)};
   margin: ${getIconMargin(props)};
 `
@@ -179,25 +175,24 @@ export const CloseIcon = styled(Button).attrs(props => {
       padding: "0rem",
     },
   }
-})<IStyledAlert>(
-  props => `
+})(
+  (props: IStyledAlert) => `
   flex-basis: 0;
   margin: ${getCloseIconMargin(props)};
-  align-self: ${({ customProps: { multiLine } }) =>
-    !multiLine ? "center" : "flex-start"};
+  align-self: ${!props.customProps.multiLine ? "center" : "flex-start"};
 `
 )
 
-export const AlertHeading = styled.div<IStyledAlert>(
-  props => `
+export const AlertHeading = styled.div(
+  (props: IStyledAlert) => `
   font-size: ${getHeadingFontSize(props)}rem;
   line-height: ${getHeadingLineHeight(props)}rem;
   margin-bottom: 0.7rem;
 `
 )
 
-export const StyledAlertPicture = styled.img<IStyledAlert>(
-  props => `
+export const StyledAlertPicture = styled.img(
+  (props: IStyledAlert) => `
   min-width: 2rem;
   height: 2rem;
   border-radius: 1.2rem;
@@ -210,8 +205,8 @@ export const StyledAlertAction = styled(Button).attrs(
   (props: IStyledAlert) => ({
     customColor: getBackgroundColor(props),
   })
-)<IStyledAlert>(
-  props => `
+)(
+  (props: IStyledAlert) => `
   flex-shrink: 0;
   text-transform: uppercase;
   font-size: ${getFontSize(props)}rem;
@@ -220,8 +215,8 @@ export const StyledAlertAction = styled(Button).attrs(
 `
 )
 
-export const AlertActionsWrapper = styled.span<IStyledAlert>(
-  props => `
+export const AlertActionsWrapper = styled.span(
+  (props: IStyledAlert) => `
   margin: ${getActionWrapperMargin(props)};
   display: flex;
   ${StyledAlertAction}:not(:last-child) {

--- a/src/components/Alerts/StyledAlert.tsx
+++ b/src/components/Alerts/StyledAlert.tsx
@@ -1,10 +1,8 @@
-import React, { ReactNode } from "react"
-import styled, { css, keyframes } from "styled-components"
-import { AlertProps } from "./types"
-import { Icon, Button } from ".."
-
+import styled from "styled-components"
+import { Button, Icon } from ".."
 import { IStyled } from "../../common/types"
 import { parseColorPreset, parseCustomColor } from "../../common/_utils"
+import { AlertProps } from "./types"
 
 type IStyledAlert = IStyled<AlertProps>
 
@@ -123,17 +121,18 @@ const getActionWrapperMargin = (props: IStyledAlert) => {
   return `${multiLine ? "1.4rem" : `0`} 0 0 0}`
 }
 
-export const AlertContainer = styled("div")<IStyledAlert>`
+export const AlertContainer = styled("div")<IStyledAlert>(
+  props => `
   display: flex;
   box-sizing: border-box;
   overflow: hidden;
 
-  width: ${props => getWidth(props)}rem;
-  border-radius: ${props => getBorderRadius(props)};
+  width: ${getWidth(props)}rem;
+  border-radius: ${getBorderRadius(props)};
   padding: 1.4rem;
 
-  color: ${props => getFontColor(props)};
-  background: ${props => getBackgroundColor(props)};
+  color: ${getFontColor(props)};
+  background: ${getBackgroundColor(props)};
 
   opacity: 1;
   transition: all 0.25s;
@@ -142,30 +141,36 @@ export const AlertContainer = styled("div")<IStyledAlert>`
     opacity: 0;
   }
 `
+)
 
-export const AlertContentWrapper = styled.div<IStyledAlert>`
+export const AlertContentWrapper = styled.div<IStyledAlert>(
+  props => `
   display: flex;
   width: 100%;
-  flex-direction: ${props => getContentWrapperDirection(props)};
+  flex-direction: ${getContentWrapperDirection(props)};
   justify-content: space-between;
-  ${({ customProps: { multiLine } }) =>
-    !multiLine ? "align-items: center;" : ""};
+  ${!props.customProps.multiLine ? "align-items: center;" : ""};
 `
+)
 
-export const AlertContent = styled.div<IStyledAlert>`
-  font-size: ${props => `${getFontSize(props)}rem`};
-  line-height: ${props => `${getLineHeight(props)}rem`};
-  color: ${props => `${getFontColor(props)}`};
+export const AlertContent = styled.div<IStyledAlert>(
+  props => `
+  font-size: ${getFontSize(props)}rem};
+  line-height: ${getLineHeight(props)}rem};
+  color: ${getFontColor(props)};
 `
+)
 
 export const StyledAlertIcon = styled(Icon).attrs(props => ({
   fill: getFontColor(props),
   width: "2rem",
   height: "2rem",
-}))<IStyledAlert>`
-  align-self: ${props => getIconVerticalAlign(props)};
-  margin: ${props => getIconMargin(props)};
+}))<IStyledAlert>(
+  props => `
+  align-self: ${getIconVerticalAlign(props)};
+  margin: ${getIconMargin(props)};
 `
+)
 
 export const CloseIcon = styled(Button).attrs(props => {
   return {
@@ -174,43 +179,53 @@ export const CloseIcon = styled(Button).attrs(props => {
       padding: "0rem",
     },
   }
-})<IStyledAlert>`
+})<IStyledAlert>(
+  props => `
   flex-basis: 0;
-  margin: ${props => getCloseIconMargin(props)};
+  margin: ${getCloseIconMargin(props)};
   align-self: ${({ customProps: { multiLine } }) =>
     !multiLine ? "center" : "flex-start"};
 `
+)
 
-export const AlertHeading = styled.div<IStyledAlert>`
-  font-size: ${props => `${getHeadingFontSize(props)}rem`};
-  line-height: ${props => `${getHeadingLineHeight(props)}rem`};
+export const AlertHeading = styled.div<IStyledAlert>(
+  props => `
+  font-size: ${getHeadingFontSize(props)}rem;
+  line-height: ${getHeadingLineHeight(props)}rem;
   margin-bottom: 0.7rem;
 `
+)
 
-export const StyledAlertPicture = styled.img<IStyledAlert>`
+export const StyledAlertPicture = styled.img<IStyledAlert>(
+  props => `
   min-width: 2rem;
   height: 2rem;
   border-radius: 1.2rem;
-  align-self: ${props => getIconVerticalAlign(props)};
-  margin: ${props => getIconMargin(props)};
+  align-self: ${getIconVerticalAlign(props)};
+  margin: ${getIconMargin(props)};
 `
+)
 
 export const StyledAlertAction = styled(Button).attrs(
   (props: IStyledAlert) => ({
     customColor: getBackgroundColor(props),
   })
-)<IStyledAlert>`
+)<IStyledAlert>(
+  props => `
   flex-shrink: 0;
   text-transform: uppercase;
-  font-size: ${props => `${getFontSize(props)}rem`};
-  line-height: ${props => `${getLineHeight(props)}rem`};
+  font-size: ${getFontSize(props)}rem;
+  line-height: ${getLineHeight(props)}rem;
   cursor: pointer;
 `
+)
 
-export const AlertActionsWrapper = styled.span<IStyledAlert>`
-  margin: ${props => getActionWrapperMargin(props)};
+export const AlertActionsWrapper = styled.span<IStyledAlert>(
+  props => `
+  margin: ${getActionWrapperMargin(props)};
   display: flex;
   ${StyledAlertAction}:not(:last-child) {
     margin-right: 0.7rem;
   }
 `
+)

--- a/src/components/Alerts/StyledAlerts.tsx
+++ b/src/components/Alerts/StyledAlerts.tsx
@@ -1,5 +1,5 @@
-import styled from "styled-components"
 import { animated } from "react-spring"
+import styled from "styled-components"
 
 const positionBoxStyle = `
 position: fixed;

--- a/src/components/Alerts/__test__/__snapshots__/Alerts.test.tsx.snap
+++ b/src/components/Alerts/__test__/__snapshots__/Alerts.test.tsx.snap
@@ -39,29 +39,12 @@ exports[`Alert Component Tests different placements bottomLeft side alert render
   fill: #ffffff;
 }
 
-.c4:hover,
-.c4:active,
-.c4:focus {
-  color: #ffffff;
-  background-color: #003d99;
-  cursor: pointer;
-}
-
-.c4:hover svg path,
-.c4:active svg path,
-.c4:focus svg path {
-  fill: #ffffff;
-}
-
-.c4:active,
-.c4:focus {
-  border: 1px solid #5ab2f2 !important;
-  box-shadow: 0px 0px 2px #0066ff;
-  outline: none;
-}
-
-.c4:hover {
-  border: 1px solid #00000000;
+.c4 function (_a) {
+  -webkit-var: disabled = _a.disabled;
+  -moz-var: disabled = _a.disabled;
+  -ms-var: disabled = _a.disabled;
+  var: disabled = _a.disabled;
+  return: !disabled && styled_components_1.css(templateObject_1 || (templateObject_1 = __makeTemplateObject(["\\n      :hover,\\n      :active,\\n      :focus {\\n        color: ",";\\n        background-color: ",";\\n        svg path {\\n          fill: ",";\\n        }\\n        cursor: pointer;\\n      }\\n      :active,\\n      :focus {\\n        border: "," !important;\\n        box-shadow: ",";\\n        outline: none;\\n      }\\n      :hover {\\n        border: ",";\\n      }\\n    "],["\\n      :hover,\\n      :active,\\n      :focus {\\n        color: ",";\\n        background-color: ",";\\n        svg path {\\n          fill: ",";\\n        }\\n        cursor: pointer;\\n      }\\n      :active,\\n      :focus {\\n        border: "," !important;\\n        box-shadow: ",";\\n        outline: none;\\n      }\\n      :hover {\\n        border: ",";\\n      }\\n    "])),getFontColor("hover",props),getBackgroundColor("hover",props),getFontColor("hover",props),getBorder("active",props),getBoxShadow(props),getBorder("hover",props));
 }
 
 .c4:disabled {
@@ -326,29 +309,12 @@ exports[`Alert Component Tests different placements bottomRight side alert rende
   fill: #ffffff;
 }
 
-.c4:hover,
-.c4:active,
-.c4:focus {
-  color: #ffffff;
-  background-color: #003d99;
-  cursor: pointer;
-}
-
-.c4:hover svg path,
-.c4:active svg path,
-.c4:focus svg path {
-  fill: #ffffff;
-}
-
-.c4:active,
-.c4:focus {
-  border: 1px solid #5ab2f2 !important;
-  box-shadow: 0px 0px 2px #0066ff;
-  outline: none;
-}
-
-.c4:hover {
-  border: 1px solid #00000000;
+.c4 function (_a) {
+  -webkit-var: disabled = _a.disabled;
+  -moz-var: disabled = _a.disabled;
+  -ms-var: disabled = _a.disabled;
+  var: disabled = _a.disabled;
+  return: !disabled && styled_components_1.css(templateObject_1 || (templateObject_1 = __makeTemplateObject(["\\n      :hover,\\n      :active,\\n      :focus {\\n        color: ",";\\n        background-color: ",";\\n        svg path {\\n          fill: ",";\\n        }\\n        cursor: pointer;\\n      }\\n      :active,\\n      :focus {\\n        border: "," !important;\\n        box-shadow: ",";\\n        outline: none;\\n      }\\n      :hover {\\n        border: ",";\\n      }\\n    "],["\\n      :hover,\\n      :active,\\n      :focus {\\n        color: ",";\\n        background-color: ",";\\n        svg path {\\n          fill: ",";\\n        }\\n        cursor: pointer;\\n      }\\n      :active,\\n      :focus {\\n        border: "," !important;\\n        box-shadow: ",";\\n        outline: none;\\n      }\\n      :hover {\\n        border: ",";\\n      }\\n    "])),getFontColor("hover",props),getBackgroundColor("hover",props),getFontColor("hover",props),getBorder("active",props),getBoxShadow(props),getBorder("hover",props));
 }
 
 .c4:disabled {
@@ -613,29 +579,12 @@ exports[`Alert Component Tests different placements topLeft side alert render 1`
   fill: #ffffff;
 }
 
-.c4:hover,
-.c4:active,
-.c4:focus {
-  color: #ffffff;
-  background-color: #003d99;
-  cursor: pointer;
-}
-
-.c4:hover svg path,
-.c4:active svg path,
-.c4:focus svg path {
-  fill: #ffffff;
-}
-
-.c4:active,
-.c4:focus {
-  border: 1px solid #5ab2f2 !important;
-  box-shadow: 0px 0px 2px #0066ff;
-  outline: none;
-}
-
-.c4:hover {
-  border: 1px solid #00000000;
+.c4 function (_a) {
+  -webkit-var: disabled = _a.disabled;
+  -moz-var: disabled = _a.disabled;
+  -ms-var: disabled = _a.disabled;
+  var: disabled = _a.disabled;
+  return: !disabled && styled_components_1.css(templateObject_1 || (templateObject_1 = __makeTemplateObject(["\\n      :hover,\\n      :active,\\n      :focus {\\n        color: ",";\\n        background-color: ",";\\n        svg path {\\n          fill: ",";\\n        }\\n        cursor: pointer;\\n      }\\n      :active,\\n      :focus {\\n        border: "," !important;\\n        box-shadow: ",";\\n        outline: none;\\n      }\\n      :hover {\\n        border: ",";\\n      }\\n    "],["\\n      :hover,\\n      :active,\\n      :focus {\\n        color: ",";\\n        background-color: ",";\\n        svg path {\\n          fill: ",";\\n        }\\n        cursor: pointer;\\n      }\\n      :active,\\n      :focus {\\n        border: "," !important;\\n        box-shadow: ",";\\n        outline: none;\\n      }\\n      :hover {\\n        border: ",";\\n      }\\n    "])),getFontColor("hover",props),getBackgroundColor("hover",props),getFontColor("hover",props),getBorder("active",props),getBoxShadow(props),getBorder("hover",props));
 }
 
 .c4:disabled {
@@ -900,29 +849,12 @@ exports[`Alert Component Tests different placements topRight side alert render 1
   fill: #ffffff;
 }
 
-.c4:hover,
-.c4:active,
-.c4:focus {
-  color: #ffffff;
-  background-color: #003d99;
-  cursor: pointer;
-}
-
-.c4:hover svg path,
-.c4:active svg path,
-.c4:focus svg path {
-  fill: #ffffff;
-}
-
-.c4:active,
-.c4:focus {
-  border: 1px solid #5ab2f2 !important;
-  box-shadow: 0px 0px 2px #0066ff;
-  outline: none;
-}
-
-.c4:hover {
-  border: 1px solid #00000000;
+.c4 function (_a) {
+  -webkit-var: disabled = _a.disabled;
+  -moz-var: disabled = _a.disabled;
+  -ms-var: disabled = _a.disabled;
+  var: disabled = _a.disabled;
+  return: !disabled && styled_components_1.css(templateObject_1 || (templateObject_1 = __makeTemplateObject(["\\n      :hover,\\n      :active,\\n      :focus {\\n        color: ",";\\n        background-color: ",";\\n        svg path {\\n          fill: ",";\\n        }\\n        cursor: pointer;\\n      }\\n      :active,\\n      :focus {\\n        border: "," !important;\\n        box-shadow: ",";\\n        outline: none;\\n      }\\n      :hover {\\n        border: ",";\\n      }\\n    "],["\\n      :hover,\\n      :active,\\n      :focus {\\n        color: ",";\\n        background-color: ",";\\n        svg path {\\n          fill: ",";\\n        }\\n        cursor: pointer;\\n      }\\n      :active,\\n      :focus {\\n        border: "," !important;\\n        box-shadow: ",";\\n        outline: none;\\n      }\\n      :hover {\\n        border: ",";\\n      }\\n    "])),getFontColor("hover",props),getBackgroundColor("hover",props),getFontColor("hover",props),getBorder("active",props),getBoxShadow(props),getBorder("hover",props));
 }
 
 .c4:disabled {
@@ -1194,29 +1126,12 @@ exports[`Alert Component Tests different sizes large alert render 1`] = `
   fill: #ffffff;
 }
 
-.c6:hover,
-.c6:active,
-.c6:focus {
-  color: #ffffff;
-  background-color: #003d99;
-  cursor: pointer;
-}
-
-.c6:hover svg path,
-.c6:active svg path,
-.c6:focus svg path {
-  fill: #ffffff;
-}
-
-.c6:active,
-.c6:focus {
-  border: 1px solid #5ab2f2 !important;
-  box-shadow: 0px 0px 2px #0066ff;
-  outline: none;
-}
-
-.c6:hover {
-  border: 1px solid #00000000;
+.c6 function (_a) {
+  -webkit-var: disabled = _a.disabled;
+  -moz-var: disabled = _a.disabled;
+  -ms-var: disabled = _a.disabled;
+  var: disabled = _a.disabled;
+  return: !disabled && styled_components_1.css(templateObject_1 || (templateObject_1 = __makeTemplateObject(["\\n      :hover,\\n      :active,\\n      :focus {\\n        color: ",";\\n        background-color: ",";\\n        svg path {\\n          fill: ",";\\n        }\\n        cursor: pointer;\\n      }\\n      :active,\\n      :focus {\\n        border: "," !important;\\n        box-shadow: ",";\\n        outline: none;\\n      }\\n      :hover {\\n        border: ",";\\n      }\\n    "],["\\n      :hover,\\n      :active,\\n      :focus {\\n        color: ",";\\n        background-color: ",";\\n        svg path {\\n          fill: ",";\\n        }\\n        cursor: pointer;\\n      }\\n      :active,\\n      :focus {\\n        border: "," !important;\\n        box-shadow: ",";\\n        outline: none;\\n      }\\n      :hover {\\n        border: ",";\\n      }\\n    "])),getFontColor("hover",props),getBackgroundColor("hover",props),getFontColor("hover",props),getBorder("active",props),getBoxShadow(props),getBorder("hover",props));
 }
 
 .c6:disabled {
@@ -1514,29 +1429,12 @@ exports[`Alert Component Tests different sizes medium alert render 1`] = `
   fill: #ffffff;
 }
 
-.c6:hover,
-.c6:active,
-.c6:focus {
-  color: #ffffff;
-  background-color: #003d99;
-  cursor: pointer;
-}
-
-.c6:hover svg path,
-.c6:active svg path,
-.c6:focus svg path {
-  fill: #ffffff;
-}
-
-.c6:active,
-.c6:focus {
-  border: 1px solid #5ab2f2 !important;
-  box-shadow: 0px 0px 2px #0066ff;
-  outline: none;
-}
-
-.c6:hover {
-  border: 1px solid #00000000;
+.c6 function (_a) {
+  -webkit-var: disabled = _a.disabled;
+  -moz-var: disabled = _a.disabled;
+  -ms-var: disabled = _a.disabled;
+  var: disabled = _a.disabled;
+  return: !disabled && styled_components_1.css(templateObject_1 || (templateObject_1 = __makeTemplateObject(["\\n      :hover,\\n      :active,\\n      :focus {\\n        color: ",";\\n        background-color: ",";\\n        svg path {\\n          fill: ",";\\n        }\\n        cursor: pointer;\\n      }\\n      :active,\\n      :focus {\\n        border: "," !important;\\n        box-shadow: ",";\\n        outline: none;\\n      }\\n      :hover {\\n        border: ",";\\n      }\\n    "],["\\n      :hover,\\n      :active,\\n      :focus {\\n        color: ",";\\n        background-color: ",";\\n        svg path {\\n          fill: ",";\\n        }\\n        cursor: pointer;\\n      }\\n      :active,\\n      :focus {\\n        border: "," !important;\\n        box-shadow: ",";\\n        outline: none;\\n      }\\n      :hover {\\n        border: ",";\\n      }\\n    "])),getFontColor("hover",props),getBackgroundColor("hover",props),getFontColor("hover",props),getBorder("active",props),getBoxShadow(props),getBorder("hover",props));
 }
 
 .c6:disabled {
@@ -1834,29 +1732,12 @@ exports[`Alert Component Tests different sizes small alert render 1`] = `
   fill: #ffffff;
 }
 
-.c6:hover,
-.c6:active,
-.c6:focus {
-  color: #ffffff;
-  background-color: #003d99;
-  cursor: pointer;
-}
-
-.c6:hover svg path,
-.c6:active svg path,
-.c6:focus svg path {
-  fill: #ffffff;
-}
-
-.c6:active,
-.c6:focus {
-  border: 1px solid #5ab2f2 !important;
-  box-shadow: 0px 0px 2px #0066ff;
-  outline: none;
-}
-
-.c6:hover {
-  border: 1px solid #00000000;
+.c6 function (_a) {
+  -webkit-var: disabled = _a.disabled;
+  -moz-var: disabled = _a.disabled;
+  -ms-var: disabled = _a.disabled;
+  var: disabled = _a.disabled;
+  return: !disabled && styled_components_1.css(templateObject_1 || (templateObject_1 = __makeTemplateObject(["\\n      :hover,\\n      :active,\\n      :focus {\\n        color: ",";\\n        background-color: ",";\\n        svg path {\\n          fill: ",";\\n        }\\n        cursor: pointer;\\n      }\\n      :active,\\n      :focus {\\n        border: "," !important;\\n        box-shadow: ",";\\n        outline: none;\\n      }\\n      :hover {\\n        border: ",";\\n      }\\n    "],["\\n      :hover,\\n      :active,\\n      :focus {\\n        color: ",";\\n        background-color: ",";\\n        svg path {\\n          fill: ",";\\n        }\\n        cursor: pointer;\\n      }\\n      :active,\\n      :focus {\\n        border: "," !important;\\n        box-shadow: ",";\\n        outline: none;\\n      }\\n      :hover {\\n        border: ",";\\n      }\\n    "])),getFontColor("hover",props),getBackgroundColor("hover",props),getFontColor("hover",props),getBorder("active",props),getBoxShadow(props),getBorder("hover",props));
 }
 
 .c6:disabled {
@@ -2154,29 +2035,12 @@ exports[`Alert Component Tests different sizes x-small alert render 1`] = `
   fill: #ffffff;
 }
 
-.c6:hover,
-.c6:active,
-.c6:focus {
-  color: #ffffff;
-  background-color: #003d99;
-  cursor: pointer;
-}
-
-.c6:hover svg path,
-.c6:active svg path,
-.c6:focus svg path {
-  fill: #ffffff;
-}
-
-.c6:active,
-.c6:focus {
-  border: 1px solid #5ab2f2 !important;
-  box-shadow: 0px 0px 2px #0066ff;
-  outline: none;
-}
-
-.c6:hover {
-  border: 1px solid #00000000;
+.c6 function (_a) {
+  -webkit-var: disabled = _a.disabled;
+  -moz-var: disabled = _a.disabled;
+  -ms-var: disabled = _a.disabled;
+  var: disabled = _a.disabled;
+  return: !disabled && styled_components_1.css(templateObject_1 || (templateObject_1 = __makeTemplateObject(["\\n      :hover,\\n      :active,\\n      :focus {\\n        color: ",";\\n        background-color: ",";\\n        svg path {\\n          fill: ",";\\n        }\\n        cursor: pointer;\\n      }\\n      :active,\\n      :focus {\\n        border: "," !important;\\n        box-shadow: ",";\\n        outline: none;\\n      }\\n      :hover {\\n        border: ",";\\n      }\\n    "],["\\n      :hover,\\n      :active,\\n      :focus {\\n        color: ",";\\n        background-color: ",";\\n        svg path {\\n          fill: ",";\\n        }\\n        cursor: pointer;\\n      }\\n      :active,\\n      :focus {\\n        border: "," !important;\\n        box-shadow: ",";\\n        outline: none;\\n      }\\n      :hover {\\n        border: ",";\\n      }\\n    "])),getFontColor("hover",props),getBackgroundColor("hover",props),getFontColor("hover",props),getBorder("active",props),getBoxShadow(props),getBorder("hover",props));
 }
 
 .c6:disabled {

--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -1,6 +1,6 @@
-import React, { FC, useContext, SyntheticEvent } from "react"
-import styled, { css, ThemeContext } from "styled-components"
 import { IStyled } from "common/types"
+import React, { FC, SyntheticEvent } from "react"
+import styled from "styled-components"
 import { oAccountCircle as UserProfileIcon } from "../Icon/Icons"
 
 interface AvatarProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
@@ -118,18 +118,19 @@ const getOpacity = props => {
   return isIcon ? 1 : 0.4
 }
 
-const AvatarBase = styled.button<IStyled<AvatarBaseProps>>`
-  width: ${({ customProps }) => customProps.size};
-  height: ${({ customProps }) => customProps.size};
+const AvatarBase = styled.button<IStyled<AvatarBaseProps>>(
+  props => `
+  width: ${props.customProps.size};
+  height: ${props.customProps.size};
 
   overflow: hidden;
   border-radius: 50%;
   outline: none;
 
   /* Style for Name Avatar */
-  color: ${props => getThemeColor(props, "Neutral90")};
-  font-size: ${props => getFontSize(props)};
-  line-height: ${props => getLineHeight(props)};
+  color: ${getThemeColor(props, "Neutral90")};
+  font-size: ${getFontSize(props)};
+  line-height: ${getLineHeight(props)};
 
   /* Below Basic Property & corresponding function calls which will play role in :
    * all three types of Avatar -
@@ -141,21 +142,21 @@ const AvatarBase = styled.button<IStyled<AvatarBaseProps>>`
    *  - hover
    *  - focus/active
    */
-  background: ${props => getBackgroundColor(props, "default")};
-  border: ${props => getBorderStyle(props, "default")};
+  background: ${getBackgroundColor(props, "default")};
+  border: ${getBorderStyle(props, "default")};
   img {
-    width: ${({ customProps }) => customProps.size};
-    height: ${({ customProps }) => customProps.size};
-    margin: ${props => getMarginStyle(props)};
+    width: ${props.customProps.size};
+    height: ${props.customProps.size};
+    margin: ${getMarginStyle(props)};
     user-drag: none;
     user-select: none;
     transition: transform 120ms;
   }
 
   svg {
-    margin: ${props => getMarginStyle(props)};
+    margin: ${getMarginStyle(props)};
     path {
-      fill: ${props => getFillColor(props, "default")};
+      fill: ${getFillColor(props, "default")};
     }
   }
 
@@ -163,30 +164,31 @@ const AvatarBase = styled.button<IStyled<AvatarBaseProps>>`
     img {
       transform: scale(1.05);
     }
-    background: ${props => getBackgroundColor(props, "hover")};
-    border: ${props => getBorderStyle(props, "hover")};
+    background: ${getBackgroundColor(props, "hover")};
+    border: ${getBorderStyle(props, "hover")};
     svg path {
-      fill: ${props => getFillColor(props, "hover")};
+      fill: ${getFillColor(props, "hover")};
     }
   }
   :focus,
   :active {
-    background: ${props => getBackgroundColor(props, "focus")};
-    border: ${props => getBorderStyle(props, "focus")};
+    background: ${getBackgroundColor(props, "focus")};
+    border: ${getBorderStyle(props, "focus")};
     svg path {
-      fill: ${props => getFillColor(props, "focus")};
+      fill: ${getFillColor(props, "focus")};
     }
-    box-shadow: ${props => getBoxShadowStyle(props)};
+    box-shadow: ${getBoxShadowStyle(props)};
   }
 
   :disabled {
     img {
       transform: none;
     }
-    opacity: ${props => getOpacity(props)};
+    opacity: ${getOpacity(props)};
     cursor: not-allowed;
   }
 `
+)
 
 const Avatar: FC<AvatarProps> = props => {
   const { picture, size = "24px", name, disabled = false, ...rest } = props

--- a/src/components/Breadcrumb/Breadcrumb.tsx
+++ b/src/components/Breadcrumb/Breadcrumb.tsx
@@ -9,14 +9,15 @@ import styled from "styled-components"
 import BreadcrumbItem, { StyledText } from "./BreadcrumbItem"
 import { BreadcrumbProps, IBreadCrumb } from "./types"
 
-const StyledParent = styled.div<BreadcrumbProps>(
-  props => `
-  display: flex;
-  max-width: ${props.maxWidth};
-  flex-wrap: wrap;
-  width: fit-content;
-  align-items: center;
-`
+const StyledParent = styled.div(
+  (props: BreadcrumbProps) =>
+    `
+      display: flex;
+      max-width: ${props.maxWidth || "initial"}
+      flex-wrap: wrap;
+      width: fit-content;
+      align-items: center;
+    `
 )
 
 const Breadcrumb: IBreadCrumb = props => {

--- a/src/components/Breadcrumb/Breadcrumb.tsx
+++ b/src/components/Breadcrumb/Breadcrumb.tsx
@@ -1,22 +1,23 @@
 import React, {
-  ReactNode,
-  ReactElement,
-  CSSProperties,
   cloneElement,
+  CSSProperties,
+  ReactElement,
+  ReactNode,
   useState,
 } from "react"
 import styled from "styled-components"
-import { StyledText } from "./BreadcrumbItem"
-import BreadcrumbItem from "./BreadcrumbItem"
+import BreadcrumbItem, { StyledText } from "./BreadcrumbItem"
 import { BreadcrumbProps, IBreadCrumb } from "./types"
 
-const StyledParent = styled.div<BreadcrumbProps>`
+const StyledParent = styled.div<BreadcrumbProps>(
+  props => `
   display: flex;
-  max-width: ${props => props.maxWidth};
+  max-width: ${props.maxWidth};
   flex-wrap: wrap;
   width: fit-content;
   align-items: center;
 `
+)
 
 const Breadcrumb: IBreadCrumb = props => {
   const {

--- a/src/components/Breadcrumb/BreadcrumbItem.tsx
+++ b/src/components/Breadcrumb/BreadcrumbItem.tsx
@@ -13,14 +13,15 @@ const sharedStyles = css<BreadcrumbItemProps>(
   display: flex;
   align-items: center;
   &:hover {
-    background-color: ${({ separator, theme: { knitui } }) =>
-      separator ? "" : knitui.chromaPalette.Neutral10};
+    background-color: ${
+      props.separator ? "" : props.theme.knitui.chromaPalette.Neutral10
+    };
   }
   cursor: ${props.separator ? "default" : "pointer"};
   a,
   * a {
     text-decoration: underline;
-    color: ${({ theme: { knitui } }) => knitui.shades.blue40};
+    color: ${props.theme.knitui.shades.blue40};
   }
 `
 )

--- a/src/components/Breadcrumb/BreadcrumbItem.tsx
+++ b/src/components/Breadcrumb/BreadcrumbItem.tsx
@@ -4,12 +4,11 @@ import { BreadcrumbItemProps } from "./types"
 
 const TYPOGRAPHY_SIZE = 14
 
-const sharedStyles = css<BreadcrumbItemProps>`
-  font-size: ${({ theme: { knitui } }) =>
-    `${knitui.typography[TYPOGRAPHY_SIZE].fontSize}rem`};
-  line-height: ${({ theme: { knitui } }) =>
-    `${knitui.typography[TYPOGRAPHY_SIZE].lineHeight}rem`};
-  border-radius: ${({ theme: { knitui } }) => knitui.inputBorderRadius};
+const sharedStyles = css<BreadcrumbItemProps>(
+  props => `
+  font-size: ${props.theme.knitui.typography[TYPOGRAPHY_SIZE].fontSize}rem;
+  line-height: ${props.theme.knitui.typography[TYPOGRAPHY_SIZE].lineHeight}rem;
+  border-radius: ${props.theme.knitui.inputBorderRadius};
   padding: 0 3px 0 3px;
   display: flex;
   align-items: center;
@@ -17,13 +16,14 @@ const sharedStyles = css<BreadcrumbItemProps>`
     background-color: ${({ separator, theme: { knitui } }) =>
       separator ? "" : knitui.chromaPalette.Neutral10};
   }
-  cursor: ${props => (props.separator ? "default" : "pointer")};
+  cursor: ${props.separator ? "default" : "pointer"};
   a,
   * a {
     text-decoration: underline;
     color: ${({ theme: { knitui } }) => knitui.shades.blue40};
   }
 `
+)
 
 export const StyledText = styled.span<BreadcrumbItemProps>`
   ${sharedStyles}

--- a/src/components/Breadcrumb/__tests__/__snapshots__/Breadcrumb.test.tsx.snap
+++ b/src/components/Breadcrumb/__tests__/__snapshots__/Breadcrumb.test.tsx.snap
@@ -87,6 +87,7 @@ exports[`Breadcrumb basic renders basic breadcrumb correctly 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  max-width: initial;
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
@@ -218,6 +219,7 @@ exports[`Breadcrumb basic renders with a custom separator correctly 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  max-width: initial;
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
@@ -349,6 +351,7 @@ exports[`Breadcrumb basic renders with a link clearly 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  max-width: initial;
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
@@ -484,6 +487,7 @@ exports[`Breadcrumb basic renders with custom child styles correctly 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  max-width: initial;
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
@@ -620,6 +624,7 @@ exports[`Breadcrumb basic renders with custom parent style correctly 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  max-width: initial;
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
@@ -700,6 +705,7 @@ exports[`Breadcrumb renders a single correctly 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  max-width: initial;
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
@@ -731,6 +737,7 @@ exports[`Breadcrumb renders no child correctly 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  max-width: initial;
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
@@ -1118,6 +1125,7 @@ exports[`Breadcrumb renders with a truncated state correctly 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  max-width: initial;
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
@@ -1259,6 +1267,7 @@ exports[`Breadcrumb renders with custom active item styles correctly 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  max-width: initial;
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
@@ -1402,6 +1411,7 @@ exports[`Breadcrumb renders with icon correctly 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  max-width: initial;
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;

--- a/src/components/Button/__tests__/__snapshots__/Button.test.tsx.snap
+++ b/src/components/Button/__tests__/__snapshots__/Button.test.tsx.snap
@@ -40,29 +40,12 @@ exports[`Button Group :  Button group : snapshot 1`] = `
   fill: #ffffff;
 }
 
-.c5:hover,
-.c5:active,
-.c5:focus {
-  color: #ffffff;
-  background-color: #003d99;
-  cursor: pointer;
-}
-
-.c5:hover svg path,
-.c5:active svg path,
-.c5:focus svg path {
-  fill: #ffffff;
-}
-
-.c5:active,
-.c5:focus {
-  border: 1px solid #5ab2f2 !important;
-  box-shadow: 0px 0px 2px #0066ff;
-  outline: none;
-}
-
-.c5:hover {
-  border: 1px solid #00000000;
+.c5 function (_a) {
+  -webkit-var: disabled = _a.disabled;
+  -moz-var: disabled = _a.disabled;
+  -ms-var: disabled = _a.disabled;
+  var: disabled = _a.disabled;
+  return: !disabled && styled_components_1.css(templateObject_1 || (templateObject_1 = __makeTemplateObject(["\\n      :hover,\\n      :active,\\n      :focus {\\n        color: ",";\\n        background-color: ",";\\n        svg path {\\n          fill: ",";\\n        }\\n        cursor: pointer;\\n      }\\n      :active,\\n      :focus {\\n        border: "," !important;\\n        box-shadow: ",";\\n        outline: none;\\n      }\\n      :hover {\\n        border: ",";\\n      }\\n    "],["\\n      :hover,\\n      :active,\\n      :focus {\\n        color: ",";\\n        background-color: ",";\\n        svg path {\\n          fill: ",";\\n        }\\n        cursor: pointer;\\n      }\\n      :active,\\n      :focus {\\n        border: "," !important;\\n        box-shadow: ",";\\n        outline: none;\\n      }\\n      :hover {\\n        border: ",";\\n      }\\n    "])),getFontColor("hover",props),getBackgroundColor("hover",props),getFontColor("hover",props),getBorder("active",props),getBoxShadow(props),getBorder("hover",props));
 }
 
 .c5:disabled {
@@ -101,29 +84,12 @@ exports[`Button Group :  Button group : snapshot 1`] = `
   fill: #ffffff;
 }
 
-.c2:hover,
-.c2:active,
-.c2:focus {
-  color: #ffffff;
-  background-color: #003d99;
-  cursor: pointer;
-}
-
-.c2:hover svg path,
-.c2:active svg path,
-.c2:focus svg path {
-  fill: #ffffff;
-}
-
-.c2:active,
-.c2:focus {
-  border: 1px solid #5ab2f2 !important;
-  box-shadow: 0px 0px 2px #0066ff;
-  outline: none;
-}
-
-.c2:hover {
-  border: 1px solid #00000000;
+.c2 function (_a) {
+  -webkit-var: disabled = _a.disabled;
+  -moz-var: disabled = _a.disabled;
+  -ms-var: disabled = _a.disabled;
+  var: disabled = _a.disabled;
+  return: !disabled && styled_components_1.css(templateObject_1 || (templateObject_1 = __makeTemplateObject(["\\n      :hover,\\n      :active,\\n      :focus {\\n        color: ",";\\n        background-color: ",";\\n        svg path {\\n          fill: ",";\\n        }\\n        cursor: pointer;\\n      }\\n      :active,\\n      :focus {\\n        border: "," !important;\\n        box-shadow: ",";\\n        outline: none;\\n      }\\n      :hover {\\n        border: ",";\\n      }\\n    "],["\\n      :hover,\\n      :active,\\n      :focus {\\n        color: ",";\\n        background-color: ",";\\n        svg path {\\n          fill: ",";\\n        }\\n        cursor: pointer;\\n      }\\n      :active,\\n      :focus {\\n        border: "," !important;\\n        box-shadow: ",";\\n        outline: none;\\n      }\\n      :hover {\\n        border: ",";\\n      }\\n    "])),getFontColor("hover",props),getBackgroundColor("hover",props),getFontColor("hover",props),getBorder("active",props),getBoxShadow(props),getBorder("hover",props));
 }
 
 .c2:disabled {
@@ -267,29 +233,12 @@ exports[`Button Group :  Button group with all ghost buttons : snapshot 1`] = `
   fill: #002966;
 }
 
-.c4:hover,
-.c4:active,
-.c4:focus {
-  color: #0066ff;
-  background-color: #ffffff;
-  cursor: pointer;
-}
-
-.c4:hover svg path,
-.c4:active svg path,
-.c4:focus svg path {
-  fill: #0066ff;
-}
-
-.c4:active,
-.c4:focus {
-  border: 1px solid #5ab2f2 !important;
-  box-shadow: 0px 0px 2px #0066ff;
-  outline: none;
-}
-
-.c4:hover {
-  border: 1px solid #0066ff;
+.c4 function (_a) {
+  -webkit-var: disabled = _a.disabled;
+  -moz-var: disabled = _a.disabled;
+  -ms-var: disabled = _a.disabled;
+  var: disabled = _a.disabled;
+  return: !disabled && styled_components_1.css(templateObject_1 || (templateObject_1 = __makeTemplateObject(["\\n      :hover,\\n      :active,\\n      :focus {\\n        color: ",";\\n        background-color: ",";\\n        svg path {\\n          fill: ",";\\n        }\\n        cursor: pointer;\\n      }\\n      :active,\\n      :focus {\\n        border: "," !important;\\n        box-shadow: ",";\\n        outline: none;\\n      }\\n      :hover {\\n        border: ",";\\n      }\\n    "],["\\n      :hover,\\n      :active,\\n      :focus {\\n        color: ",";\\n        background-color: ",";\\n        svg path {\\n          fill: ",";\\n        }\\n        cursor: pointer;\\n      }\\n      :active,\\n      :focus {\\n        border: "," !important;\\n        box-shadow: ",";\\n        outline: none;\\n      }\\n      :hover {\\n        border: ",";\\n      }\\n    "])),getFontColor("hover",props),getBackgroundColor("hover",props),getFontColor("hover",props),getBorder("active",props),getBoxShadow(props),getBorder("hover",props));
 }
 
 .c4:disabled {
@@ -328,29 +277,12 @@ exports[`Button Group :  Button group with all ghost buttons : snapshot 1`] = `
   fill: #002966;
 }
 
-.c2:hover,
-.c2:active,
-.c2:focus {
-  color: #0066ff;
-  background-color: #ffffff;
-  cursor: pointer;
-}
-
-.c2:hover svg path,
-.c2:active svg path,
-.c2:focus svg path {
-  fill: #0066ff;
-}
-
-.c2:active,
-.c2:focus {
-  border: 1px solid #5ab2f2 !important;
-  box-shadow: 0px 0px 2px #0066ff;
-  outline: none;
-}
-
-.c2:hover {
-  border: 1px solid #0066ff;
+.c2 function (_a) {
+  -webkit-var: disabled = _a.disabled;
+  -moz-var: disabled = _a.disabled;
+  -ms-var: disabled = _a.disabled;
+  var: disabled = _a.disabled;
+  return: !disabled && styled_components_1.css(templateObject_1 || (templateObject_1 = __makeTemplateObject(["\\n      :hover,\\n      :active,\\n      :focus {\\n        color: ",";\\n        background-color: ",";\\n        svg path {\\n          fill: ",";\\n        }\\n        cursor: pointer;\\n      }\\n      :active,\\n      :focus {\\n        border: "," !important;\\n        box-shadow: ",";\\n        outline: none;\\n      }\\n      :hover {\\n        border: ",";\\n      }\\n    "],["\\n      :hover,\\n      :active,\\n      :focus {\\n        color: ",";\\n        background-color: ",";\\n        svg path {\\n          fill: ",";\\n        }\\n        cursor: pointer;\\n      }\\n      :active,\\n      :focus {\\n        border: "," !important;\\n        box-shadow: ",";\\n        outline: none;\\n      }\\n      :hover {\\n        border: ",";\\n      }\\n    "])),getFontColor("hover",props),getBackgroundColor("hover",props),getFontColor("hover",props),getBorder("active",props),getBoxShadow(props),getBorder("hover",props));
 }
 
 .c2:disabled {
@@ -511,6 +443,14 @@ exports[`Button Should disable button rendered correctly 1`] = `
   fill: #ffffff;
 }
 
+.c0 function (_a) {
+  -webkit-var: disabled = _a.disabled;
+  -moz-var: disabled = _a.disabled;
+  -ms-var: disabled = _a.disabled;
+  var: disabled = _a.disabled;
+  return: !disabled && styled_components_1.css(templateObject_1 || (templateObject_1 = __makeTemplateObject(["\\n      :hover,\\n      :active,\\n      :focus {\\n        color: ",";\\n        background-color: ",";\\n        svg path {\\n          fill: ",";\\n        }\\n        cursor: pointer;\\n      }\\n      :active,\\n      :focus {\\n        border: "," !important;\\n        box-shadow: ",";\\n        outline: none;\\n      }\\n      :hover {\\n        border: ",";\\n      }\\n    "],["\\n      :hover,\\n      :active,\\n      :focus {\\n        color: ",";\\n        background-color: ",";\\n        svg path {\\n          fill: ",";\\n        }\\n        cursor: pointer;\\n      }\\n      :active,\\n      :focus {\\n        border: "," !important;\\n        box-shadow: ",";\\n        outline: none;\\n      }\\n      :hover {\\n        border: ",";\\n      }\\n    "])),getFontColor("hover",props),getBackgroundColor("hover",props),getFontColor("hover",props),getBorder("active",props),getBoxShadow(props),getBorder("hover",props));
+}
+
 .c0:disabled {
   opacity: 0.5;
   cursor: not-allowed;
@@ -558,29 +498,12 @@ exports[`Button renders with a custom color object correctly 1`] = `
   fill: #873421;
 }
 
-.c0:hover,
-.c0:active,
-.c0:focus {
-  color: #873421;
-  background-color: #ed12f1;
-  cursor: pointer;
-}
-
-.c0:hover svg path,
-.c0:active svg path,
-.c0:focus svg path {
-  fill: #873421;
-}
-
-.c0:active,
-.c0:focus {
-  border: 1px solid #5ab2f2 !important;
-  box-shadow: 0px 0px 2px #0066ff;
-  outline: none;
-}
-
-.c0:hover {
-  border: 1px solid #00000000;
+.c0 function (_a) {
+  -webkit-var: disabled = _a.disabled;
+  -moz-var: disabled = _a.disabled;
+  -ms-var: disabled = _a.disabled;
+  var: disabled = _a.disabled;
+  return: !disabled && styled_components_1.css(templateObject_1 || (templateObject_1 = __makeTemplateObject(["\\n      :hover,\\n      :active,\\n      :focus {\\n        color: ",";\\n        background-color: ",";\\n        svg path {\\n          fill: ",";\\n        }\\n        cursor: pointer;\\n      }\\n      :active,\\n      :focus {\\n        border: "," !important;\\n        box-shadow: ",";\\n        outline: none;\\n      }\\n      :hover {\\n        border: ",";\\n      }\\n    "],["\\n      :hover,\\n      :active,\\n      :focus {\\n        color: ",";\\n        background-color: ",";\\n        svg path {\\n          fill: ",";\\n        }\\n        cursor: pointer;\\n      }\\n      :active,\\n      :focus {\\n        border: "," !important;\\n        box-shadow: ",";\\n        outline: none;\\n      }\\n      :hover {\\n        border: ",";\\n      }\\n    "])),getFontColor("hover",props),getBackgroundColor("hover",props),getFontColor("hover",props),getBorder("active",props),getBoxShadow(props),getBorder("hover",props));
 }
 
 .c0:disabled {
@@ -629,29 +552,12 @@ exports[`Button renders with a custom color object correctly 2`] = `
   fill: #873421;
 }
 
-.c0:hover,
-.c0:active,
-.c0:focus {
-  color: #873421;
-  background-color: #ed12f1;
-  cursor: pointer;
-}
-
-.c0:hover svg path,
-.c0:active svg path,
-.c0:focus svg path {
-  fill: #873421;
-}
-
-.c0:active,
-.c0:focus {
-  border: 1px solid #5ab2f2 !important;
-  box-shadow: 0px 0px 2px #0066ff;
-  outline: none;
-}
-
-.c0:hover {
-  border: 1px solid #00000000;
+.c0 function (_a) {
+  -webkit-var: disabled = _a.disabled;
+  -moz-var: disabled = _a.disabled;
+  -ms-var: disabled = _a.disabled;
+  var: disabled = _a.disabled;
+  return: !disabled && styled_components_1.css(templateObject_1 || (templateObject_1 = __makeTemplateObject(["\\n      :hover,\\n      :active,\\n      :focus {\\n        color: ",";\\n        background-color: ",";\\n        svg path {\\n          fill: ",";\\n        }\\n        cursor: pointer;\\n      }\\n      :active,\\n      :focus {\\n        border: "," !important;\\n        box-shadow: ",";\\n        outline: none;\\n      }\\n      :hover {\\n        border: ",";\\n      }\\n    "],["\\n      :hover,\\n      :active,\\n      :focus {\\n        color: ",";\\n        background-color: ",";\\n        svg path {\\n          fill: ",";\\n        }\\n        cursor: pointer;\\n      }\\n      :active,\\n      :focus {\\n        border: "," !important;\\n        box-shadow: ",";\\n        outline: none;\\n      }\\n      :hover {\\n        border: ",";\\n      }\\n    "])),getFontColor("hover",props),getBackgroundColor("hover",props),getFontColor("hover",props),getBorder("active",props),getBoxShadow(props),getBorder("hover",props));
 }
 
 .c0:disabled {
@@ -700,29 +606,12 @@ exports[`Button renders with a custom color object correctly 3`] = `
   fill: #873421;
 }
 
-.c0:hover,
-.c0:active,
-.c0:focus {
-  color: #873421;
-  background-color: #ed12f1;
-  cursor: pointer;
-}
-
-.c0:hover svg path,
-.c0:active svg path,
-.c0:focus svg path {
-  fill: #873421;
-}
-
-.c0:active,
-.c0:focus {
-  border: 1px solid #5ab2f2 !important;
-  box-shadow: 0px 0px 2px #0066ff;
-  outline: none;
-}
-
-.c0:hover {
-  border: 1px solid #00000000;
+.c0 function (_a) {
+  -webkit-var: disabled = _a.disabled;
+  -moz-var: disabled = _a.disabled;
+  -ms-var: disabled = _a.disabled;
+  var: disabled = _a.disabled;
+  return: !disabled && styled_components_1.css(templateObject_1 || (templateObject_1 = __makeTemplateObject(["\\n      :hover,\\n      :active,\\n      :focus {\\n        color: ",";\\n        background-color: ",";\\n        svg path {\\n          fill: ",";\\n        }\\n        cursor: pointer;\\n      }\\n      :active,\\n      :focus {\\n        border: "," !important;\\n        box-shadow: ",";\\n        outline: none;\\n      }\\n      :hover {\\n        border: ",";\\n      }\\n    "],["\\n      :hover,\\n      :active,\\n      :focus {\\n        color: ",";\\n        background-color: ",";\\n        svg path {\\n          fill: ",";\\n        }\\n        cursor: pointer;\\n      }\\n      :active,\\n      :focus {\\n        border: "," !important;\\n        box-shadow: ",";\\n        outline: none;\\n      }\\n      :hover {\\n        border: ",";\\n      }\\n    "])),getFontColor("hover",props),getBackgroundColor("hover",props),getFontColor("hover",props),getBorder("active",props),getBoxShadow(props),getBorder("hover",props));
 }
 
 .c0:disabled {
@@ -771,29 +660,12 @@ exports[`Button renders with a custom color theme correctly 1`] = `
   fill: #1a1a1a;
 }
 
-.c0:hover,
-.c0:active,
-.c0:focus {
-  color: #1a1a1a;
-  background-color: #ed12f1;
-  cursor: pointer;
-}
-
-.c0:hover svg path,
-.c0:active svg path,
-.c0:focus svg path {
-  fill: #1a1a1a;
-}
-
-.c0:active,
-.c0:focus {
-  border: 1px solid #5ab2f2 !important;
-  box-shadow: 0px 0px 2px #0066ff;
-  outline: none;
-}
-
-.c0:hover {
-  border: 1px solid #00000000;
+.c0 function (_a) {
+  -webkit-var: disabled = _a.disabled;
+  -moz-var: disabled = _a.disabled;
+  -ms-var: disabled = _a.disabled;
+  var: disabled = _a.disabled;
+  return: !disabled && styled_components_1.css(templateObject_1 || (templateObject_1 = __makeTemplateObject(["\\n      :hover,\\n      :active,\\n      :focus {\\n        color: ",";\\n        background-color: ",";\\n        svg path {\\n          fill: ",";\\n        }\\n        cursor: pointer;\\n      }\\n      :active,\\n      :focus {\\n        border: "," !important;\\n        box-shadow: ",";\\n        outline: none;\\n      }\\n      :hover {\\n        border: ",";\\n      }\\n    "],["\\n      :hover,\\n      :active,\\n      :focus {\\n        color: ",";\\n        background-color: ",";\\n        svg path {\\n          fill: ",";\\n        }\\n        cursor: pointer;\\n      }\\n      :active,\\n      :focus {\\n        border: "," !important;\\n        box-shadow: ",";\\n        outline: none;\\n      }\\n      :hover {\\n        border: ",";\\n      }\\n    "])),getFontColor("hover",props),getBackgroundColor("hover",props),getFontColor("hover",props),getBorder("active",props),getBoxShadow(props),getBorder("hover",props));
 }
 
 .c0:disabled {
@@ -842,29 +714,12 @@ exports[`Button renders with a custom color theme correctly 2`] = `
   fill: #1a1a1a;
 }
 
-.c0:hover,
-.c0:active,
-.c0:focus {
-  color: #1a1a1a;
-  background-color: #ed12f1;
-  cursor: pointer;
-}
-
-.c0:hover svg path,
-.c0:active svg path,
-.c0:focus svg path {
-  fill: #1a1a1a;
-}
-
-.c0:active,
-.c0:focus {
-  border: 1px solid #5ab2f2 !important;
-  box-shadow: 0px 0px 2px #0066ff;
-  outline: none;
-}
-
-.c0:hover {
-  border: 1px solid #00000000;
+.c0 function (_a) {
+  -webkit-var: disabled = _a.disabled;
+  -moz-var: disabled = _a.disabled;
+  -ms-var: disabled = _a.disabled;
+  var: disabled = _a.disabled;
+  return: !disabled && styled_components_1.css(templateObject_1 || (templateObject_1 = __makeTemplateObject(["\\n      :hover,\\n      :active,\\n      :focus {\\n        color: ",";\\n        background-color: ",";\\n        svg path {\\n          fill: ",";\\n        }\\n        cursor: pointer;\\n      }\\n      :active,\\n      :focus {\\n        border: "," !important;\\n        box-shadow: ",";\\n        outline: none;\\n      }\\n      :hover {\\n        border: ",";\\n      }\\n    "],["\\n      :hover,\\n      :active,\\n      :focus {\\n        color: ",";\\n        background-color: ",";\\n        svg path {\\n          fill: ",";\\n        }\\n        cursor: pointer;\\n      }\\n      :active,\\n      :focus {\\n        border: "," !important;\\n        box-shadow: ",";\\n        outline: none;\\n      }\\n      :hover {\\n        border: ",";\\n      }\\n    "])),getFontColor("hover",props),getBackgroundColor("hover",props),getFontColor("hover",props),getBorder("active",props),getBoxShadow(props),getBorder("hover",props));
 }
 
 .c0:disabled {
@@ -913,29 +768,12 @@ exports[`Button renders with a custom color theme correctly 3`] = `
   fill: #1a1a1a;
 }
 
-.c0:hover,
-.c0:active,
-.c0:focus {
-  color: #1a1a1a;
-  background-color: #ed12f1;
-  cursor: pointer;
-}
-
-.c0:hover svg path,
-.c0:active svg path,
-.c0:focus svg path {
-  fill: #1a1a1a;
-}
-
-.c0:active,
-.c0:focus {
-  border: 1px solid #5ab2f2 !important;
-  box-shadow: 0px 0px 2px #0066ff;
-  outline: none;
-}
-
-.c0:hover {
-  border: 1px solid #00000000;
+.c0 function (_a) {
+  -webkit-var: disabled = _a.disabled;
+  -moz-var: disabled = _a.disabled;
+  -ms-var: disabled = _a.disabled;
+  var: disabled = _a.disabled;
+  return: !disabled && styled_components_1.css(templateObject_1 || (templateObject_1 = __makeTemplateObject(["\\n      :hover,\\n      :active,\\n      :focus {\\n        color: ",";\\n        background-color: ",";\\n        svg path {\\n          fill: ",";\\n        }\\n        cursor: pointer;\\n      }\\n      :active,\\n      :focus {\\n        border: "," !important;\\n        box-shadow: ",";\\n        outline: none;\\n      }\\n      :hover {\\n        border: ",";\\n      }\\n    "],["\\n      :hover,\\n      :active,\\n      :focus {\\n        color: ",";\\n        background-color: ",";\\n        svg path {\\n          fill: ",";\\n        }\\n        cursor: pointer;\\n      }\\n      :active,\\n      :focus {\\n        border: "," !important;\\n        box-shadow: ",";\\n        outline: none;\\n      }\\n      :hover {\\n        border: ",";\\n      }\\n    "])),getFontColor("hover",props),getBackgroundColor("hover",props),getFontColor("hover",props),getBorder("active",props),getBoxShadow(props),getBorder("hover",props));
 }
 
 .c0:disabled {
@@ -984,29 +822,12 @@ exports[`Button renders with a specified color preset correctly 1`] = `
   fill: #ffffff;
 }
 
-.c0:hover,
-.c0:active,
-.c0:focus {
-  color: #ffffff;
-  background-color: #cc0000;
-  cursor: pointer;
-}
-
-.c0:hover svg path,
-.c0:active svg path,
-.c0:focus svg path {
-  fill: #ffffff;
-}
-
-.c0:active,
-.c0:focus {
-  border: 1px solid #5ab2f2 !important;
-  box-shadow: 0px 0px 2px #0066ff;
-  outline: none;
-}
-
-.c0:hover {
-  border: 1px solid #00000000;
+.c0 function (_a) {
+  -webkit-var: disabled = _a.disabled;
+  -moz-var: disabled = _a.disabled;
+  -ms-var: disabled = _a.disabled;
+  var: disabled = _a.disabled;
+  return: !disabled && styled_components_1.css(templateObject_1 || (templateObject_1 = __makeTemplateObject(["\\n      :hover,\\n      :active,\\n      :focus {\\n        color: ",";\\n        background-color: ",";\\n        svg path {\\n          fill: ",";\\n        }\\n        cursor: pointer;\\n      }\\n      :active,\\n      :focus {\\n        border: "," !important;\\n        box-shadow: ",";\\n        outline: none;\\n      }\\n      :hover {\\n        border: ",";\\n      }\\n    "],["\\n      :hover,\\n      :active,\\n      :focus {\\n        color: ",";\\n        background-color: ",";\\n        svg path {\\n          fill: ",";\\n        }\\n        cursor: pointer;\\n      }\\n      :active,\\n      :focus {\\n        border: "," !important;\\n        box-shadow: ",";\\n        outline: none;\\n      }\\n      :hover {\\n        border: ",";\\n      }\\n    "])),getFontColor("hover",props),getBackgroundColor("hover",props),getFontColor("hover",props),getBorder("active",props),getBoxShadow(props),getBorder("hover",props));
 }
 
 .c0:disabled {
@@ -1055,29 +876,12 @@ exports[`Button renders with a specified color preset correctly 2`] = `
   fill: #ffffff;
 }
 
-.c0:hover,
-.c0:active,
-.c0:focus {
-  color: #ffffff;
-  background-color: #cc0000;
-  cursor: pointer;
-}
-
-.c0:hover svg path,
-.c0:active svg path,
-.c0:focus svg path {
-  fill: #ffffff;
-}
-
-.c0:active,
-.c0:focus {
-  border: 1px solid #5ab2f2 !important;
-  box-shadow: 0px 0px 2px #0066ff;
-  outline: none;
-}
-
-.c0:hover {
-  border: 1px solid #00000000;
+.c0 function (_a) {
+  -webkit-var: disabled = _a.disabled;
+  -moz-var: disabled = _a.disabled;
+  -ms-var: disabled = _a.disabled;
+  var: disabled = _a.disabled;
+  return: !disabled && styled_components_1.css(templateObject_1 || (templateObject_1 = __makeTemplateObject(["\\n      :hover,\\n      :active,\\n      :focus {\\n        color: ",";\\n        background-color: ",";\\n        svg path {\\n          fill: ",";\\n        }\\n        cursor: pointer;\\n      }\\n      :active,\\n      :focus {\\n        border: "," !important;\\n        box-shadow: ",";\\n        outline: none;\\n      }\\n      :hover {\\n        border: ",";\\n      }\\n    "],["\\n      :hover,\\n      :active,\\n      :focus {\\n        color: ",";\\n        background-color: ",";\\n        svg path {\\n          fill: ",";\\n        }\\n        cursor: pointer;\\n      }\\n      :active,\\n      :focus {\\n        border: "," !important;\\n        box-shadow: ",";\\n        outline: none;\\n      }\\n      :hover {\\n        border: ",";\\n      }\\n    "])),getFontColor("hover",props),getBackgroundColor("hover",props),getFontColor("hover",props),getBorder("active",props),getBoxShadow(props),getBorder("hover",props));
 }
 
 .c0:disabled {
@@ -1126,29 +930,12 @@ exports[`Button renders with a specified color preset correctly 3`] = `
   fill: #ffffff;
 }
 
-.c0:hover,
-.c0:active,
-.c0:focus {
-  color: #ffffff;
-  background-color: #cc0000;
-  cursor: pointer;
-}
-
-.c0:hover svg path,
-.c0:active svg path,
-.c0:focus svg path {
-  fill: #ffffff;
-}
-
-.c0:active,
-.c0:focus {
-  border: 1px solid #5ab2f2 !important;
-  box-shadow: 0px 0px 2px #0066ff;
-  outline: none;
-}
-
-.c0:hover {
-  border: 1px solid #00000000;
+.c0 function (_a) {
+  -webkit-var: disabled = _a.disabled;
+  -moz-var: disabled = _a.disabled;
+  -ms-var: disabled = _a.disabled;
+  var: disabled = _a.disabled;
+  return: !disabled && styled_components_1.css(templateObject_1 || (templateObject_1 = __makeTemplateObject(["\\n      :hover,\\n      :active,\\n      :focus {\\n        color: ",";\\n        background-color: ",";\\n        svg path {\\n          fill: ",";\\n        }\\n        cursor: pointer;\\n      }\\n      :active,\\n      :focus {\\n        border: "," !important;\\n        box-shadow: ",";\\n        outline: none;\\n      }\\n      :hover {\\n        border: ",";\\n      }\\n    "],["\\n      :hover,\\n      :active,\\n      :focus {\\n        color: ",";\\n        background-color: ",";\\n        svg path {\\n          fill: ",";\\n        }\\n        cursor: pointer;\\n      }\\n      :active,\\n      :focus {\\n        border: "," !important;\\n        box-shadow: ",";\\n        outline: none;\\n      }\\n      :hover {\\n        border: ",";\\n      }\\n    "])),getFontColor("hover",props),getBackgroundColor("hover",props),getFontColor("hover",props),getBorder("active",props),getBoxShadow(props),getBorder("hover",props));
 }
 
 .c0:disabled {
@@ -1197,29 +984,12 @@ exports[`Button renders with inset correctly 1`] = `
   fill: #ffffff;
 }
 
-.c0:hover,
-.c0:active,
-.c0:focus {
-  color: #ffffff;
-  background-color: #003d99;
-  cursor: pointer;
-}
-
-.c0:hover svg path,
-.c0:active svg path,
-.c0:focus svg path {
-  fill: #ffffff;
-}
-
-.c0:active,
-.c0:focus {
-  border: 1px solid #5ab2f2 !important;
-  box-shadow: 0px 0px 2px #0066ff;
-  outline: none;
-}
-
-.c0:hover {
-  border: 1px solid #00000000;
+.c0 function (_a) {
+  -webkit-var: disabled = _a.disabled;
+  -moz-var: disabled = _a.disabled;
+  -ms-var: disabled = _a.disabled;
+  var: disabled = _a.disabled;
+  return: !disabled && styled_components_1.css(templateObject_1 || (templateObject_1 = __makeTemplateObject(["\\n      :hover,\\n      :active,\\n      :focus {\\n        color: ",";\\n        background-color: ",";\\n        svg path {\\n          fill: ",";\\n        }\\n        cursor: pointer;\\n      }\\n      :active,\\n      :focus {\\n        border: "," !important;\\n        box-shadow: ",";\\n        outline: none;\\n      }\\n      :hover {\\n        border: ",";\\n      }\\n    "],["\\n      :hover,\\n      :active,\\n      :focus {\\n        color: ",";\\n        background-color: ",";\\n        svg path {\\n          fill: ",";\\n        }\\n        cursor: pointer;\\n      }\\n      :active,\\n      :focus {\\n        border: "," !important;\\n        box-shadow: ",";\\n        outline: none;\\n      }\\n      :hover {\\n        border: ",";\\n      }\\n    "])),getFontColor("hover",props),getBackgroundColor("hover",props),getFontColor("hover",props),getBorder("active",props),getBoxShadow(props),getBorder("hover",props));
 }
 
 .c0:disabled {
@@ -1287,29 +1057,12 @@ exports[`Button renders with inset correctly 2`] = `
   fill: #ffffff;
 }
 
-.c0:hover,
-.c0:active,
-.c0:focus {
-  color: #ffffff;
-  background-color: #003d99;
-  cursor: pointer;
-}
-
-.c0:hover svg path,
-.c0:active svg path,
-.c0:focus svg path {
-  fill: #ffffff;
-}
-
-.c0:active,
-.c0:focus {
-  border: 1px solid #5ab2f2 !important;
-  box-shadow: 0px 0px 2px #0066ff;
-  outline: none;
-}
-
-.c0:hover {
-  border: 1px solid #00000000;
+.c0 function (_a) {
+  -webkit-var: disabled = _a.disabled;
+  -moz-var: disabled = _a.disabled;
+  -ms-var: disabled = _a.disabled;
+  var: disabled = _a.disabled;
+  return: !disabled && styled_components_1.css(templateObject_1 || (templateObject_1 = __makeTemplateObject(["\\n      :hover,\\n      :active,\\n      :focus {\\n        color: ",";\\n        background-color: ",";\\n        svg path {\\n          fill: ",";\\n        }\\n        cursor: pointer;\\n      }\\n      :active,\\n      :focus {\\n        border: "," !important;\\n        box-shadow: ",";\\n        outline: none;\\n      }\\n      :hover {\\n        border: ",";\\n      }\\n    "],["\\n      :hover,\\n      :active,\\n      :focus {\\n        color: ",";\\n        background-color: ",";\\n        svg path {\\n          fill: ",";\\n        }\\n        cursor: pointer;\\n      }\\n      :active,\\n      :focus {\\n        border: "," !important;\\n        box-shadow: ",";\\n        outline: none;\\n      }\\n      :hover {\\n        border: ",";\\n      }\\n    "])),getFontColor("hover",props),getBackgroundColor("hover",props),getFontColor("hover",props),getBorder("active",props),getBoxShadow(props),getBorder("hover",props));
 }
 
 .c0:disabled {
@@ -1377,29 +1130,12 @@ exports[`Button renders with inset correctly 3`] = `
   fill: #ffffff;
 }
 
-.c0:hover,
-.c0:active,
-.c0:focus {
-  color: #ffffff;
-  background-color: #003d99;
-  cursor: pointer;
-}
-
-.c0:hover svg path,
-.c0:active svg path,
-.c0:focus svg path {
-  fill: #ffffff;
-}
-
-.c0:active,
-.c0:focus {
-  border: 1px solid #5ab2f2 !important;
-  box-shadow: 0px 0px 2px #0066ff;
-  outline: none;
-}
-
-.c0:hover {
-  border: 1px solid #00000000;
+.c0 function (_a) {
+  -webkit-var: disabled = _a.disabled;
+  -moz-var: disabled = _a.disabled;
+  -ms-var: disabled = _a.disabled;
+  var: disabled = _a.disabled;
+  return: !disabled && styled_components_1.css(templateObject_1 || (templateObject_1 = __makeTemplateObject(["\\n      :hover,\\n      :active,\\n      :focus {\\n        color: ",";\\n        background-color: ",";\\n        svg path {\\n          fill: ",";\\n        }\\n        cursor: pointer;\\n      }\\n      :active,\\n      :focus {\\n        border: "," !important;\\n        box-shadow: ",";\\n        outline: none;\\n      }\\n      :hover {\\n        border: ",";\\n      }\\n    "],["\\n      :hover,\\n      :active,\\n      :focus {\\n        color: ",";\\n        background-color: ",";\\n        svg path {\\n          fill: ",";\\n        }\\n        cursor: pointer;\\n      }\\n      :active,\\n      :focus {\\n        border: "," !important;\\n        box-shadow: ",";\\n        outline: none;\\n      }\\n      :hover {\\n        border: ",";\\n      }\\n    "])),getFontColor("hover",props),getBackgroundColor("hover",props),getFontColor("hover",props),getBorder("active",props),getBoxShadow(props),getBorder("hover",props));
 }
 
 .c0:disabled {
@@ -1474,29 +1210,12 @@ exports[`Button renders with text and an icon correctly 1`] = `
   fill: #ffffff;
 }
 
-.c0:hover,
-.c0:active,
-.c0:focus {
-  color: #ffffff;
-  background-color: #003d99;
-  cursor: pointer;
-}
-
-.c0:hover svg path,
-.c0:active svg path,
-.c0:focus svg path {
-  fill: #ffffff;
-}
-
-.c0:active,
-.c0:focus {
-  border: 1px solid #5ab2f2 !important;
-  box-shadow: 0px 0px 2px #0066ff;
-  outline: none;
-}
-
-.c0:hover {
-  border: 1px solid #00000000;
+.c0 function (_a) {
+  -webkit-var: disabled = _a.disabled;
+  -moz-var: disabled = _a.disabled;
+  -ms-var: disabled = _a.disabled;
+  var: disabled = _a.disabled;
+  return: !disabled && styled_components_1.css(templateObject_1 || (templateObject_1 = __makeTemplateObject(["\\n      :hover,\\n      :active,\\n      :focus {\\n        color: ",";\\n        background-color: ",";\\n        svg path {\\n          fill: ",";\\n        }\\n        cursor: pointer;\\n      }\\n      :active,\\n      :focus {\\n        border: "," !important;\\n        box-shadow: ",";\\n        outline: none;\\n      }\\n      :hover {\\n        border: ",";\\n      }\\n    "],["\\n      :hover,\\n      :active,\\n      :focus {\\n        color: ",";\\n        background-color: ",";\\n        svg path {\\n          fill: ",";\\n        }\\n        cursor: pointer;\\n      }\\n      :active,\\n      :focus {\\n        border: "," !important;\\n        box-shadow: ",";\\n        outline: none;\\n      }\\n      :hover {\\n        border: ",";\\n      }\\n    "])),getFontColor("hover",props),getBackgroundColor("hover",props),getFontColor("hover",props),getBorder("active",props),getBoxShadow(props),getBorder("hover",props));
 }
 
 .c0:disabled {
@@ -1570,29 +1289,12 @@ exports[`Button renders with text and an icon correctly 2`] = `
   fill: #ffffff;
 }
 
-.c0:hover,
-.c0:active,
-.c0:focus {
-  color: #ffffff;
-  background-color: #003d99;
-  cursor: pointer;
-}
-
-.c0:hover svg path,
-.c0:active svg path,
-.c0:focus svg path {
-  fill: #ffffff;
-}
-
-.c0:active,
-.c0:focus {
-  border: 1px solid #5ab2f2 !important;
-  box-shadow: 0px 0px 2px #0066ff;
-  outline: none;
-}
-
-.c0:hover {
-  border: 1px solid #00000000;
+.c0 function (_a) {
+  -webkit-var: disabled = _a.disabled;
+  -moz-var: disabled = _a.disabled;
+  -ms-var: disabled = _a.disabled;
+  var: disabled = _a.disabled;
+  return: !disabled && styled_components_1.css(templateObject_1 || (templateObject_1 = __makeTemplateObject(["\\n      :hover,\\n      :active,\\n      :focus {\\n        color: ",";\\n        background-color: ",";\\n        svg path {\\n          fill: ",";\\n        }\\n        cursor: pointer;\\n      }\\n      :active,\\n      :focus {\\n        border: "," !important;\\n        box-shadow: ",";\\n        outline: none;\\n      }\\n      :hover {\\n        border: ",";\\n      }\\n    "],["\\n      :hover,\\n      :active,\\n      :focus {\\n        color: ",";\\n        background-color: ",";\\n        svg path {\\n          fill: ",";\\n        }\\n        cursor: pointer;\\n      }\\n      :active,\\n      :focus {\\n        border: "," !important;\\n        box-shadow: ",";\\n        outline: none;\\n      }\\n      :hover {\\n        border: ",";\\n      }\\n    "])),getFontColor("hover",props),getBackgroundColor("hover",props),getFontColor("hover",props),getBorder("active",props),getBoxShadow(props),getBorder("hover",props));
 }
 
 .c0:disabled {
@@ -1666,29 +1368,12 @@ exports[`Button renders with text and an icon correctly 3`] = `
   fill: #ffffff;
 }
 
-.c0:hover,
-.c0:active,
-.c0:focus {
-  color: #ffffff;
-  background-color: #003d99;
-  cursor: pointer;
-}
-
-.c0:hover svg path,
-.c0:active svg path,
-.c0:focus svg path {
-  fill: #ffffff;
-}
-
-.c0:active,
-.c0:focus {
-  border: 1px solid #5ab2f2 !important;
-  box-shadow: 0px 0px 2px #0066ff;
-  outline: none;
-}
-
-.c0:hover {
-  border: 1px solid #00000000;
+.c0 function (_a) {
+  -webkit-var: disabled = _a.disabled;
+  -moz-var: disabled = _a.disabled;
+  -ms-var: disabled = _a.disabled;
+  var: disabled = _a.disabled;
+  return: !disabled && styled_components_1.css(templateObject_1 || (templateObject_1 = __makeTemplateObject(["\\n      :hover,\\n      :active,\\n      :focus {\\n        color: ",";\\n        background-color: ",";\\n        svg path {\\n          fill: ",";\\n        }\\n        cursor: pointer;\\n      }\\n      :active,\\n      :focus {\\n        border: "," !important;\\n        box-shadow: ",";\\n        outline: none;\\n      }\\n      :hover {\\n        border: ",";\\n      }\\n    "],["\\n      :hover,\\n      :active,\\n      :focus {\\n        color: ",";\\n        background-color: ",";\\n        svg path {\\n          fill: ",";\\n        }\\n        cursor: pointer;\\n      }\\n      :active,\\n      :focus {\\n        border: "," !important;\\n        box-shadow: ",";\\n        outline: none;\\n      }\\n      :hover {\\n        border: ",";\\n      }\\n    "])),getFontColor("hover",props),getBackgroundColor("hover",props),getFontColor("hover",props),getBorder("active",props),getBoxShadow(props),getBorder("hover",props));
 }
 
 .c0:disabled {
@@ -1762,29 +1447,12 @@ exports[`Button renders with text, icon and inset correctly 1`] = `
   fill: #ffffff;
 }
 
-.c0:hover,
-.c0:active,
-.c0:focus {
-  color: #ffffff;
-  background-color: #003d99;
-  cursor: pointer;
-}
-
-.c0:hover svg path,
-.c0:active svg path,
-.c0:focus svg path {
-  fill: #ffffff;
-}
-
-.c0:active,
-.c0:focus {
-  border: 1px solid #5ab2f2 !important;
-  box-shadow: 0px 0px 2px #0066ff;
-  outline: none;
-}
-
-.c0:hover {
-  border: 1px solid #00000000;
+.c0 function (_a) {
+  -webkit-var: disabled = _a.disabled;
+  -moz-var: disabled = _a.disabled;
+  -ms-var: disabled = _a.disabled;
+  var: disabled = _a.disabled;
+  return: !disabled && styled_components_1.css(templateObject_1 || (templateObject_1 = __makeTemplateObject(["\\n      :hover,\\n      :active,\\n      :focus {\\n        color: ",";\\n        background-color: ",";\\n        svg path {\\n          fill: ",";\\n        }\\n        cursor: pointer;\\n      }\\n      :active,\\n      :focus {\\n        border: "," !important;\\n        box-shadow: ",";\\n        outline: none;\\n      }\\n      :hover {\\n        border: ",";\\n      }\\n    "],["\\n      :hover,\\n      :active,\\n      :focus {\\n        color: ",";\\n        background-color: ",";\\n        svg path {\\n          fill: ",";\\n        }\\n        cursor: pointer;\\n      }\\n      :active,\\n      :focus {\\n        border: "," !important;\\n        box-shadow: ",";\\n        outline: none;\\n      }\\n      :hover {\\n        border: ",";\\n      }\\n    "])),getFontColor("hover",props),getBackgroundColor("hover",props),getFontColor("hover",props),getBorder("active",props),getBoxShadow(props),getBorder("hover",props));
 }
 
 .c0:disabled {
@@ -1877,29 +1545,12 @@ exports[`Button renders with text, icon and inset correctly 2`] = `
   fill: #ffffff;
 }
 
-.c0:hover,
-.c0:active,
-.c0:focus {
-  color: #ffffff;
-  background-color: #003d99;
-  cursor: pointer;
-}
-
-.c0:hover svg path,
-.c0:active svg path,
-.c0:focus svg path {
-  fill: #ffffff;
-}
-
-.c0:active,
-.c0:focus {
-  border: 1px solid #5ab2f2 !important;
-  box-shadow: 0px 0px 2px #0066ff;
-  outline: none;
-}
-
-.c0:hover {
-  border: 1px solid #00000000;
+.c0 function (_a) {
+  -webkit-var: disabled = _a.disabled;
+  -moz-var: disabled = _a.disabled;
+  -ms-var: disabled = _a.disabled;
+  var: disabled = _a.disabled;
+  return: !disabled && styled_components_1.css(templateObject_1 || (templateObject_1 = __makeTemplateObject(["\\n      :hover,\\n      :active,\\n      :focus {\\n        color: ",";\\n        background-color: ",";\\n        svg path {\\n          fill: ",";\\n        }\\n        cursor: pointer;\\n      }\\n      :active,\\n      :focus {\\n        border: "," !important;\\n        box-shadow: ",";\\n        outline: none;\\n      }\\n      :hover {\\n        border: ",";\\n      }\\n    "],["\\n      :hover,\\n      :active,\\n      :focus {\\n        color: ",";\\n        background-color: ",";\\n        svg path {\\n          fill: ",";\\n        }\\n        cursor: pointer;\\n      }\\n      :active,\\n      :focus {\\n        border: "," !important;\\n        box-shadow: ",";\\n        outline: none;\\n      }\\n      :hover {\\n        border: ",";\\n      }\\n    "])),getFontColor("hover",props),getBackgroundColor("hover",props),getFontColor("hover",props),getBorder("active",props),getBoxShadow(props),getBorder("hover",props));
 }
 
 .c0:disabled {
@@ -1992,29 +1643,12 @@ exports[`Button renders with text, icon and inset correctly 3`] = `
   fill: #ffffff;
 }
 
-.c0:hover,
-.c0:active,
-.c0:focus {
-  color: #ffffff;
-  background-color: #003d99;
-  cursor: pointer;
-}
-
-.c0:hover svg path,
-.c0:active svg path,
-.c0:focus svg path {
-  fill: #ffffff;
-}
-
-.c0:active,
-.c0:focus {
-  border: 1px solid #5ab2f2 !important;
-  box-shadow: 0px 0px 2px #0066ff;
-  outline: none;
-}
-
-.c0:hover {
-  border: 1px solid #00000000;
+.c0 function (_a) {
+  -webkit-var: disabled = _a.disabled;
+  -moz-var: disabled = _a.disabled;
+  -ms-var: disabled = _a.disabled;
+  var: disabled = _a.disabled;
+  return: !disabled && styled_components_1.css(templateObject_1 || (templateObject_1 = __makeTemplateObject(["\\n      :hover,\\n      :active,\\n      :focus {\\n        color: ",";\\n        background-color: ",";\\n        svg path {\\n          fill: ",";\\n        }\\n        cursor: pointer;\\n      }\\n      :active,\\n      :focus {\\n        border: "," !important;\\n        box-shadow: ",";\\n        outline: none;\\n      }\\n      :hover {\\n        border: ",";\\n      }\\n    "],["\\n      :hover,\\n      :active,\\n      :focus {\\n        color: ",";\\n        background-color: ",";\\n        svg path {\\n          fill: ",";\\n        }\\n        cursor: pointer;\\n      }\\n      :active,\\n      :focus {\\n        border: "," !important;\\n        box-shadow: ",";\\n        outline: none;\\n      }\\n      :hover {\\n        border: ",";\\n      }\\n    "])),getFontColor("hover",props),getBackgroundColor("hover",props),getFontColor("hover",props),getBorder("active",props),getBoxShadow(props),getBorder("hover",props));
 }
 
 .c0:disabled {
@@ -2100,29 +1734,12 @@ exports[`Button with size large renders a bare variant correctly 1`] = `
   fill: #002966;
 }
 
-.c0:hover,
-.c0:active,
-.c0:focus {
-  color: #003d99;
-  background-color: #f2f2f2;
-  cursor: pointer;
-}
-
-.c0:hover svg path,
-.c0:active svg path,
-.c0:focus svg path {
-  fill: #003d99;
-}
-
-.c0:active,
-.c0:focus {
-  border: 1px solid #5ab2f2 !important;
-  box-shadow: 0px 0px 2px #0066ff;
-  outline: none;
-}
-
-.c0:hover {
-  border: 1px solid #00000000;
+.c0 function (_a) {
+  -webkit-var: disabled = _a.disabled;
+  -moz-var: disabled = _a.disabled;
+  -ms-var: disabled = _a.disabled;
+  var: disabled = _a.disabled;
+  return: !disabled && styled_components_1.css(templateObject_1 || (templateObject_1 = __makeTemplateObject(["\\n      :hover,\\n      :active,\\n      :focus {\\n        color: ",";\\n        background-color: ",";\\n        svg path {\\n          fill: ",";\\n        }\\n        cursor: pointer;\\n      }\\n      :active,\\n      :focus {\\n        border: "," !important;\\n        box-shadow: ",";\\n        outline: none;\\n      }\\n      :hover {\\n        border: ",";\\n      }\\n    "],["\\n      :hover,\\n      :active,\\n      :focus {\\n        color: ",";\\n        background-color: ",";\\n        svg path {\\n          fill: ",";\\n        }\\n        cursor: pointer;\\n      }\\n      :active,\\n      :focus {\\n        border: "," !important;\\n        box-shadow: ",";\\n        outline: none;\\n      }\\n      :hover {\\n        border: ",";\\n      }\\n    "])),getFontColor("hover",props),getBackgroundColor("hover",props),getFontColor("hover",props),getBorder("active",props),getBoxShadow(props),getBorder("hover",props));
 }
 
 .c0:disabled {
@@ -2171,29 +1788,12 @@ exports[`Button with size large renders a ghost variant correctly 1`] = `
   fill: #002966;
 }
 
-.c0:hover,
-.c0:active,
-.c0:focus {
-  color: #0066ff;
-  background-color: #ffffff;
-  cursor: pointer;
-}
-
-.c0:hover svg path,
-.c0:active svg path,
-.c0:focus svg path {
-  fill: #0066ff;
-}
-
-.c0:active,
-.c0:focus {
-  border: 1px solid #5ab2f2 !important;
-  box-shadow: 0px 0px 2px #0066ff;
-  outline: none;
-}
-
-.c0:hover {
-  border: 1px solid #0066ff;
+.c0 function (_a) {
+  -webkit-var: disabled = _a.disabled;
+  -moz-var: disabled = _a.disabled;
+  -ms-var: disabled = _a.disabled;
+  var: disabled = _a.disabled;
+  return: !disabled && styled_components_1.css(templateObject_1 || (templateObject_1 = __makeTemplateObject(["\\n      :hover,\\n      :active,\\n      :focus {\\n        color: ",";\\n        background-color: ",";\\n        svg path {\\n          fill: ",";\\n        }\\n        cursor: pointer;\\n      }\\n      :active,\\n      :focus {\\n        border: "," !important;\\n        box-shadow: ",";\\n        outline: none;\\n      }\\n      :hover {\\n        border: ",";\\n      }\\n    "],["\\n      :hover,\\n      :active,\\n      :focus {\\n        color: ",";\\n        background-color: ",";\\n        svg path {\\n          fill: ",";\\n        }\\n        cursor: pointer;\\n      }\\n      :active,\\n      :focus {\\n        border: "," !important;\\n        box-shadow: ",";\\n        outline: none;\\n      }\\n      :hover {\\n        border: ",";\\n      }\\n    "])),getFontColor("hover",props),getBackgroundColor("hover",props),getFontColor("hover",props),getBorder("active",props),getBoxShadow(props),getBorder("hover",props));
 }
 
 .c0:disabled {
@@ -2242,29 +1842,12 @@ exports[`Button with size large renders a primary variant with a label correctly
   fill: #ffffff;
 }
 
-.c0:hover,
-.c0:active,
-.c0:focus {
-  color: #ffffff;
-  background-color: #003d99;
-  cursor: pointer;
-}
-
-.c0:hover svg path,
-.c0:active svg path,
-.c0:focus svg path {
-  fill: #ffffff;
-}
-
-.c0:active,
-.c0:focus {
-  border: 1px solid #5ab2f2 !important;
-  box-shadow: 0px 0px 2px #0066ff;
-  outline: none;
-}
-
-.c0:hover {
-  border: 1px solid #00000000;
+.c0 function (_a) {
+  -webkit-var: disabled = _a.disabled;
+  -moz-var: disabled = _a.disabled;
+  -ms-var: disabled = _a.disabled;
+  var: disabled = _a.disabled;
+  return: !disabled && styled_components_1.css(templateObject_1 || (templateObject_1 = __makeTemplateObject(["\\n      :hover,\\n      :active,\\n      :focus {\\n        color: ",";\\n        background-color: ",";\\n        svg path {\\n          fill: ",";\\n        }\\n        cursor: pointer;\\n      }\\n      :active,\\n      :focus {\\n        border: "," !important;\\n        box-shadow: ",";\\n        outline: none;\\n      }\\n      :hover {\\n        border: ",";\\n      }\\n    "],["\\n      :hover,\\n      :active,\\n      :focus {\\n        color: ",";\\n        background-color: ",";\\n        svg path {\\n          fill: ",";\\n        }\\n        cursor: pointer;\\n      }\\n      :active,\\n      :focus {\\n        border: "," !important;\\n        box-shadow: ",";\\n        outline: none;\\n      }\\n      :hover {\\n        border: ",";\\n      }\\n    "])),getFontColor("hover",props),getBackgroundColor("hover",props),getFontColor("hover",props),getBorder("active",props),getBoxShadow(props),getBorder("hover",props));
 }
 
 .c0:disabled {
@@ -2313,29 +1896,12 @@ exports[`Button with size large renders a primary variant with a label correctly
   fill: #ffffff;
 }
 
-.c0:hover,
-.c0:active,
-.c0:focus {
-  color: #ffffff;
-  background-color: #003d99;
-  cursor: pointer;
-}
-
-.c0:hover svg path,
-.c0:active svg path,
-.c0:focus svg path {
-  fill: #ffffff;
-}
-
-.c0:active,
-.c0:focus {
-  border: 1px solid #5ab2f2 !important;
-  box-shadow: 0px 0px 2px #0066ff;
-  outline: none;
-}
-
-.c0:hover {
-  border: 1px solid #00000000;
+.c0 function (_a) {
+  -webkit-var: disabled = _a.disabled;
+  -moz-var: disabled = _a.disabled;
+  -ms-var: disabled = _a.disabled;
+  var: disabled = _a.disabled;
+  return: !disabled && styled_components_1.css(templateObject_1 || (templateObject_1 = __makeTemplateObject(["\\n      :hover,\\n      :active,\\n      :focus {\\n        color: ",";\\n        background-color: ",";\\n        svg path {\\n          fill: ",";\\n        }\\n        cursor: pointer;\\n      }\\n      :active,\\n      :focus {\\n        border: "," !important;\\n        box-shadow: ",";\\n        outline: none;\\n      }\\n      :hover {\\n        border: ",";\\n      }\\n    "],["\\n      :hover,\\n      :active,\\n      :focus {\\n        color: ",";\\n        background-color: ",";\\n        svg path {\\n          fill: ",";\\n        }\\n        cursor: pointer;\\n      }\\n      :active,\\n      :focus {\\n        border: "," !important;\\n        box-shadow: ",";\\n        outline: none;\\n      }\\n      :hover {\\n        border: ",";\\n      }\\n    "])),getFontColor("hover",props),getBackgroundColor("hover",props),getFontColor("hover",props),getBorder("active",props),getBoxShadow(props),getBorder("hover",props));
 }
 
 .c0:disabled {
@@ -2391,29 +1957,12 @@ exports[`Button with size large renders with a bare icon correctly 1`] = `
   fill: #002966;
 }
 
-.c0:hover,
-.c0:active,
-.c0:focus {
-  color: #003d99;
-  background-color: #f2f2f2;
-  cursor: pointer;
-}
-
-.c0:hover svg path,
-.c0:active svg path,
-.c0:focus svg path {
-  fill: #003d99;
-}
-
-.c0:active,
-.c0:focus {
-  border: 1px solid #5ab2f2 !important;
-  box-shadow: 0px 0px 2px #0066ff;
-  outline: none;
-}
-
-.c0:hover {
-  border: 1px solid #00000000;
+.c0 function (_a) {
+  -webkit-var: disabled = _a.disabled;
+  -moz-var: disabled = _a.disabled;
+  -ms-var: disabled = _a.disabled;
+  var: disabled = _a.disabled;
+  return: !disabled && styled_components_1.css(templateObject_1 || (templateObject_1 = __makeTemplateObject(["\\n      :hover,\\n      :active,\\n      :focus {\\n        color: ",";\\n        background-color: ",";\\n        svg path {\\n          fill: ",";\\n        }\\n        cursor: pointer;\\n      }\\n      :active,\\n      :focus {\\n        border: "," !important;\\n        box-shadow: ",";\\n        outline: none;\\n      }\\n      :hover {\\n        border: ",";\\n      }\\n    "],["\\n      :hover,\\n      :active,\\n      :focus {\\n        color: ",";\\n        background-color: ",";\\n        svg path {\\n          fill: ",";\\n        }\\n        cursor: pointer;\\n      }\\n      :active,\\n      :focus {\\n        border: "," !important;\\n        box-shadow: ",";\\n        outline: none;\\n      }\\n      :hover {\\n        border: ",";\\n      }\\n    "])),getFontColor("hover",props),getBackgroundColor("hover",props),getFontColor("hover",props),getBorder("active",props),getBoxShadow(props),getBorder("hover",props));
 }
 
 .c0:disabled {
@@ -2487,29 +2036,12 @@ exports[`Button with size large renders with an icon correctly 1`] = `
   fill: #ffffff;
 }
 
-.c0:hover,
-.c0:active,
-.c0:focus {
-  color: #ffffff;
-  background-color: #003d99;
-  cursor: pointer;
-}
-
-.c0:hover svg path,
-.c0:active svg path,
-.c0:focus svg path {
-  fill: #ffffff;
-}
-
-.c0:active,
-.c0:focus {
-  border: 1px solid #5ab2f2 !important;
-  box-shadow: 0px 0px 2px #0066ff;
-  outline: none;
-}
-
-.c0:hover {
-  border: 1px solid #00000000;
+.c0 function (_a) {
+  -webkit-var: disabled = _a.disabled;
+  -moz-var: disabled = _a.disabled;
+  -ms-var: disabled = _a.disabled;
+  var: disabled = _a.disabled;
+  return: !disabled && styled_components_1.css(templateObject_1 || (templateObject_1 = __makeTemplateObject(["\\n      :hover,\\n      :active,\\n      :focus {\\n        color: ",";\\n        background-color: ",";\\n        svg path {\\n          fill: ",";\\n        }\\n        cursor: pointer;\\n      }\\n      :active,\\n      :focus {\\n        border: "," !important;\\n        box-shadow: ",";\\n        outline: none;\\n      }\\n      :hover {\\n        border: ",";\\n      }\\n    "],["\\n      :hover,\\n      :active,\\n      :focus {\\n        color: ",";\\n        background-color: ",";\\n        svg path {\\n          fill: ",";\\n        }\\n        cursor: pointer;\\n      }\\n      :active,\\n      :focus {\\n        border: "," !important;\\n        box-shadow: ",";\\n        outline: none;\\n      }\\n      :hover {\\n        border: ",";\\n      }\\n    "])),getFontColor("hover",props),getBackgroundColor("hover",props),getFontColor("hover",props),getBorder("active",props),getBoxShadow(props),getBorder("hover",props));
 }
 
 .c0:disabled {
@@ -2576,29 +2108,12 @@ exports[`Button with size medium renders a bare variant correctly 1`] = `
   fill: #002966;
 }
 
-.c0:hover,
-.c0:active,
-.c0:focus {
-  color: #003d99;
-  background-color: #f2f2f2;
-  cursor: pointer;
-}
-
-.c0:hover svg path,
-.c0:active svg path,
-.c0:focus svg path {
-  fill: #003d99;
-}
-
-.c0:active,
-.c0:focus {
-  border: 1px solid #5ab2f2 !important;
-  box-shadow: 0px 0px 2px #0066ff;
-  outline: none;
-}
-
-.c0:hover {
-  border: 1px solid #00000000;
+.c0 function (_a) {
+  -webkit-var: disabled = _a.disabled;
+  -moz-var: disabled = _a.disabled;
+  -ms-var: disabled = _a.disabled;
+  var: disabled = _a.disabled;
+  return: !disabled && styled_components_1.css(templateObject_1 || (templateObject_1 = __makeTemplateObject(["\\n      :hover,\\n      :active,\\n      :focus {\\n        color: ",";\\n        background-color: ",";\\n        svg path {\\n          fill: ",";\\n        }\\n        cursor: pointer;\\n      }\\n      :active,\\n      :focus {\\n        border: "," !important;\\n        box-shadow: ",";\\n        outline: none;\\n      }\\n      :hover {\\n        border: ",";\\n      }\\n    "],["\\n      :hover,\\n      :active,\\n      :focus {\\n        color: ",";\\n        background-color: ",";\\n        svg path {\\n          fill: ",";\\n        }\\n        cursor: pointer;\\n      }\\n      :active,\\n      :focus {\\n        border: "," !important;\\n        box-shadow: ",";\\n        outline: none;\\n      }\\n      :hover {\\n        border: ",";\\n      }\\n    "])),getFontColor("hover",props),getBackgroundColor("hover",props),getFontColor("hover",props),getBorder("active",props),getBoxShadow(props),getBorder("hover",props));
 }
 
 .c0:disabled {
@@ -2647,29 +2162,12 @@ exports[`Button with size medium renders a ghost variant correctly 1`] = `
   fill: #002966;
 }
 
-.c0:hover,
-.c0:active,
-.c0:focus {
-  color: #0066ff;
-  background-color: #ffffff;
-  cursor: pointer;
-}
-
-.c0:hover svg path,
-.c0:active svg path,
-.c0:focus svg path {
-  fill: #0066ff;
-}
-
-.c0:active,
-.c0:focus {
-  border: 1px solid #5ab2f2 !important;
-  box-shadow: 0px 0px 2px #0066ff;
-  outline: none;
-}
-
-.c0:hover {
-  border: 1px solid #0066ff;
+.c0 function (_a) {
+  -webkit-var: disabled = _a.disabled;
+  -moz-var: disabled = _a.disabled;
+  -ms-var: disabled = _a.disabled;
+  var: disabled = _a.disabled;
+  return: !disabled && styled_components_1.css(templateObject_1 || (templateObject_1 = __makeTemplateObject(["\\n      :hover,\\n      :active,\\n      :focus {\\n        color: ",";\\n        background-color: ",";\\n        svg path {\\n          fill: ",";\\n        }\\n        cursor: pointer;\\n      }\\n      :active,\\n      :focus {\\n        border: "," !important;\\n        box-shadow: ",";\\n        outline: none;\\n      }\\n      :hover {\\n        border: ",";\\n      }\\n    "],["\\n      :hover,\\n      :active,\\n      :focus {\\n        color: ",";\\n        background-color: ",";\\n        svg path {\\n          fill: ",";\\n        }\\n        cursor: pointer;\\n      }\\n      :active,\\n      :focus {\\n        border: "," !important;\\n        box-shadow: ",";\\n        outline: none;\\n      }\\n      :hover {\\n        border: ",";\\n      }\\n    "])),getFontColor("hover",props),getBackgroundColor("hover",props),getFontColor("hover",props),getBorder("active",props),getBoxShadow(props),getBorder("hover",props));
 }
 
 .c0:disabled {
@@ -2718,29 +2216,12 @@ exports[`Button with size medium renders a primary variant with a label correctl
   fill: #ffffff;
 }
 
-.c0:hover,
-.c0:active,
-.c0:focus {
-  color: #ffffff;
-  background-color: #003d99;
-  cursor: pointer;
-}
-
-.c0:hover svg path,
-.c0:active svg path,
-.c0:focus svg path {
-  fill: #ffffff;
-}
-
-.c0:active,
-.c0:focus {
-  border: 1px solid #5ab2f2 !important;
-  box-shadow: 0px 0px 2px #0066ff;
-  outline: none;
-}
-
-.c0:hover {
-  border: 1px solid #00000000;
+.c0 function (_a) {
+  -webkit-var: disabled = _a.disabled;
+  -moz-var: disabled = _a.disabled;
+  -ms-var: disabled = _a.disabled;
+  var: disabled = _a.disabled;
+  return: !disabled && styled_components_1.css(templateObject_1 || (templateObject_1 = __makeTemplateObject(["\\n      :hover,\\n      :active,\\n      :focus {\\n        color: ",";\\n        background-color: ",";\\n        svg path {\\n          fill: ",";\\n        }\\n        cursor: pointer;\\n      }\\n      :active,\\n      :focus {\\n        border: "," !important;\\n        box-shadow: ",";\\n        outline: none;\\n      }\\n      :hover {\\n        border: ",";\\n      }\\n    "],["\\n      :hover,\\n      :active,\\n      :focus {\\n        color: ",";\\n        background-color: ",";\\n        svg path {\\n          fill: ",";\\n        }\\n        cursor: pointer;\\n      }\\n      :active,\\n      :focus {\\n        border: "," !important;\\n        box-shadow: ",";\\n        outline: none;\\n      }\\n      :hover {\\n        border: ",";\\n      }\\n    "])),getFontColor("hover",props),getBackgroundColor("hover",props),getFontColor("hover",props),getBorder("active",props),getBoxShadow(props),getBorder("hover",props));
 }
 
 .c0:disabled {
@@ -2789,29 +2270,12 @@ exports[`Button with size medium renders a primary variant with a label correctl
   fill: #ffffff;
 }
 
-.c0:hover,
-.c0:active,
-.c0:focus {
-  color: #ffffff;
-  background-color: #003d99;
-  cursor: pointer;
-}
-
-.c0:hover svg path,
-.c0:active svg path,
-.c0:focus svg path {
-  fill: #ffffff;
-}
-
-.c0:active,
-.c0:focus {
-  border: 1px solid #5ab2f2 !important;
-  box-shadow: 0px 0px 2px #0066ff;
-  outline: none;
-}
-
-.c0:hover {
-  border: 1px solid #00000000;
+.c0 function (_a) {
+  -webkit-var: disabled = _a.disabled;
+  -moz-var: disabled = _a.disabled;
+  -ms-var: disabled = _a.disabled;
+  var: disabled = _a.disabled;
+  return: !disabled && styled_components_1.css(templateObject_1 || (templateObject_1 = __makeTemplateObject(["\\n      :hover,\\n      :active,\\n      :focus {\\n        color: ",";\\n        background-color: ",";\\n        svg path {\\n          fill: ",";\\n        }\\n        cursor: pointer;\\n      }\\n      :active,\\n      :focus {\\n        border: "," !important;\\n        box-shadow: ",";\\n        outline: none;\\n      }\\n      :hover {\\n        border: ",";\\n      }\\n    "],["\\n      :hover,\\n      :active,\\n      :focus {\\n        color: ",";\\n        background-color: ",";\\n        svg path {\\n          fill: ",";\\n        }\\n        cursor: pointer;\\n      }\\n      :active,\\n      :focus {\\n        border: "," !important;\\n        box-shadow: ",";\\n        outline: none;\\n      }\\n      :hover {\\n        border: ",";\\n      }\\n    "])),getFontColor("hover",props),getBackgroundColor("hover",props),getFontColor("hover",props),getBorder("active",props),getBoxShadow(props),getBorder("hover",props));
 }
 
 .c0:disabled {
@@ -2867,29 +2331,12 @@ exports[`Button with size medium renders with a bare icon correctly 1`] = `
   fill: #002966;
 }
 
-.c0:hover,
-.c0:active,
-.c0:focus {
-  color: #003d99;
-  background-color: #f2f2f2;
-  cursor: pointer;
-}
-
-.c0:hover svg path,
-.c0:active svg path,
-.c0:focus svg path {
-  fill: #003d99;
-}
-
-.c0:active,
-.c0:focus {
-  border: 1px solid #5ab2f2 !important;
-  box-shadow: 0px 0px 2px #0066ff;
-  outline: none;
-}
-
-.c0:hover {
-  border: 1px solid #00000000;
+.c0 function (_a) {
+  -webkit-var: disabled = _a.disabled;
+  -moz-var: disabled = _a.disabled;
+  -ms-var: disabled = _a.disabled;
+  var: disabled = _a.disabled;
+  return: !disabled && styled_components_1.css(templateObject_1 || (templateObject_1 = __makeTemplateObject(["\\n      :hover,\\n      :active,\\n      :focus {\\n        color: ",";\\n        background-color: ",";\\n        svg path {\\n          fill: ",";\\n        }\\n        cursor: pointer;\\n      }\\n      :active,\\n      :focus {\\n        border: "," !important;\\n        box-shadow: ",";\\n        outline: none;\\n      }\\n      :hover {\\n        border: ",";\\n      }\\n    "],["\\n      :hover,\\n      :active,\\n      :focus {\\n        color: ",";\\n        background-color: ",";\\n        svg path {\\n          fill: ",";\\n        }\\n        cursor: pointer;\\n      }\\n      :active,\\n      :focus {\\n        border: "," !important;\\n        box-shadow: ",";\\n        outline: none;\\n      }\\n      :hover {\\n        border: ",";\\n      }\\n    "])),getFontColor("hover",props),getBackgroundColor("hover",props),getFontColor("hover",props),getBorder("active",props),getBoxShadow(props),getBorder("hover",props));
 }
 
 .c0:disabled {
@@ -2963,29 +2410,12 @@ exports[`Button with size medium renders with an icon correctly 1`] = `
   fill: #ffffff;
 }
 
-.c0:hover,
-.c0:active,
-.c0:focus {
-  color: #ffffff;
-  background-color: #003d99;
-  cursor: pointer;
-}
-
-.c0:hover svg path,
-.c0:active svg path,
-.c0:focus svg path {
-  fill: #ffffff;
-}
-
-.c0:active,
-.c0:focus {
-  border: 1px solid #5ab2f2 !important;
-  box-shadow: 0px 0px 2px #0066ff;
-  outline: none;
-}
-
-.c0:hover {
-  border: 1px solid #00000000;
+.c0 function (_a) {
+  -webkit-var: disabled = _a.disabled;
+  -moz-var: disabled = _a.disabled;
+  -ms-var: disabled = _a.disabled;
+  var: disabled = _a.disabled;
+  return: !disabled && styled_components_1.css(templateObject_1 || (templateObject_1 = __makeTemplateObject(["\\n      :hover,\\n      :active,\\n      :focus {\\n        color: ",";\\n        background-color: ",";\\n        svg path {\\n          fill: ",";\\n        }\\n        cursor: pointer;\\n      }\\n      :active,\\n      :focus {\\n        border: "," !important;\\n        box-shadow: ",";\\n        outline: none;\\n      }\\n      :hover {\\n        border: ",";\\n      }\\n    "],["\\n      :hover,\\n      :active,\\n      :focus {\\n        color: ",";\\n        background-color: ",";\\n        svg path {\\n          fill: ",";\\n        }\\n        cursor: pointer;\\n      }\\n      :active,\\n      :focus {\\n        border: "," !important;\\n        box-shadow: ",";\\n        outline: none;\\n      }\\n      :hover {\\n        border: ",";\\n      }\\n    "])),getFontColor("hover",props),getBackgroundColor("hover",props),getFontColor("hover",props),getBorder("active",props),getBoxShadow(props),getBorder("hover",props));
 }
 
 .c0:disabled {
@@ -3052,29 +2482,12 @@ exports[`Button with size small renders a bare variant correctly 1`] = `
   fill: #002966;
 }
 
-.c0:hover,
-.c0:active,
-.c0:focus {
-  color: #003d99;
-  background-color: #f2f2f2;
-  cursor: pointer;
-}
-
-.c0:hover svg path,
-.c0:active svg path,
-.c0:focus svg path {
-  fill: #003d99;
-}
-
-.c0:active,
-.c0:focus {
-  border: 1px solid #5ab2f2 !important;
-  box-shadow: 0px 0px 2px #0066ff;
-  outline: none;
-}
-
-.c0:hover {
-  border: 1px solid #00000000;
+.c0 function (_a) {
+  -webkit-var: disabled = _a.disabled;
+  -moz-var: disabled = _a.disabled;
+  -ms-var: disabled = _a.disabled;
+  var: disabled = _a.disabled;
+  return: !disabled && styled_components_1.css(templateObject_1 || (templateObject_1 = __makeTemplateObject(["\\n      :hover,\\n      :active,\\n      :focus {\\n        color: ",";\\n        background-color: ",";\\n        svg path {\\n          fill: ",";\\n        }\\n        cursor: pointer;\\n      }\\n      :active,\\n      :focus {\\n        border: "," !important;\\n        box-shadow: ",";\\n        outline: none;\\n      }\\n      :hover {\\n        border: ",";\\n      }\\n    "],["\\n      :hover,\\n      :active,\\n      :focus {\\n        color: ",";\\n        background-color: ",";\\n        svg path {\\n          fill: ",";\\n        }\\n        cursor: pointer;\\n      }\\n      :active,\\n      :focus {\\n        border: "," !important;\\n        box-shadow: ",";\\n        outline: none;\\n      }\\n      :hover {\\n        border: ",";\\n      }\\n    "])),getFontColor("hover",props),getBackgroundColor("hover",props),getFontColor("hover",props),getBorder("active",props),getBoxShadow(props),getBorder("hover",props));
 }
 
 .c0:disabled {
@@ -3123,29 +2536,12 @@ exports[`Button with size small renders a ghost variant correctly 1`] = `
   fill: #002966;
 }
 
-.c0:hover,
-.c0:active,
-.c0:focus {
-  color: #0066ff;
-  background-color: #ffffff;
-  cursor: pointer;
-}
-
-.c0:hover svg path,
-.c0:active svg path,
-.c0:focus svg path {
-  fill: #0066ff;
-}
-
-.c0:active,
-.c0:focus {
-  border: 1px solid #5ab2f2 !important;
-  box-shadow: 0px 0px 2px #0066ff;
-  outline: none;
-}
-
-.c0:hover {
-  border: 1px solid #0066ff;
+.c0 function (_a) {
+  -webkit-var: disabled = _a.disabled;
+  -moz-var: disabled = _a.disabled;
+  -ms-var: disabled = _a.disabled;
+  var: disabled = _a.disabled;
+  return: !disabled && styled_components_1.css(templateObject_1 || (templateObject_1 = __makeTemplateObject(["\\n      :hover,\\n      :active,\\n      :focus {\\n        color: ",";\\n        background-color: ",";\\n        svg path {\\n          fill: ",";\\n        }\\n        cursor: pointer;\\n      }\\n      :active,\\n      :focus {\\n        border: "," !important;\\n        box-shadow: ",";\\n        outline: none;\\n      }\\n      :hover {\\n        border: ",";\\n      }\\n    "],["\\n      :hover,\\n      :active,\\n      :focus {\\n        color: ",";\\n        background-color: ",";\\n        svg path {\\n          fill: ",";\\n        }\\n        cursor: pointer;\\n      }\\n      :active,\\n      :focus {\\n        border: "," !important;\\n        box-shadow: ",";\\n        outline: none;\\n      }\\n      :hover {\\n        border: ",";\\n      }\\n    "])),getFontColor("hover",props),getBackgroundColor("hover",props),getFontColor("hover",props),getBorder("active",props),getBoxShadow(props),getBorder("hover",props));
 }
 
 .c0:disabled {
@@ -3194,29 +2590,12 @@ exports[`Button with size small renders a primary variant with a label correctly
   fill: #ffffff;
 }
 
-.c0:hover,
-.c0:active,
-.c0:focus {
-  color: #ffffff;
-  background-color: #003d99;
-  cursor: pointer;
-}
-
-.c0:hover svg path,
-.c0:active svg path,
-.c0:focus svg path {
-  fill: #ffffff;
-}
-
-.c0:active,
-.c0:focus {
-  border: 1px solid #5ab2f2 !important;
-  box-shadow: 0px 0px 2px #0066ff;
-  outline: none;
-}
-
-.c0:hover {
-  border: 1px solid #00000000;
+.c0 function (_a) {
+  -webkit-var: disabled = _a.disabled;
+  -moz-var: disabled = _a.disabled;
+  -ms-var: disabled = _a.disabled;
+  var: disabled = _a.disabled;
+  return: !disabled && styled_components_1.css(templateObject_1 || (templateObject_1 = __makeTemplateObject(["\\n      :hover,\\n      :active,\\n      :focus {\\n        color: ",";\\n        background-color: ",";\\n        svg path {\\n          fill: ",";\\n        }\\n        cursor: pointer;\\n      }\\n      :active,\\n      :focus {\\n        border: "," !important;\\n        box-shadow: ",";\\n        outline: none;\\n      }\\n      :hover {\\n        border: ",";\\n      }\\n    "],["\\n      :hover,\\n      :active,\\n      :focus {\\n        color: ",";\\n        background-color: ",";\\n        svg path {\\n          fill: ",";\\n        }\\n        cursor: pointer;\\n      }\\n      :active,\\n      :focus {\\n        border: "," !important;\\n        box-shadow: ",";\\n        outline: none;\\n      }\\n      :hover {\\n        border: ",";\\n      }\\n    "])),getFontColor("hover",props),getBackgroundColor("hover",props),getFontColor("hover",props),getBorder("active",props),getBoxShadow(props),getBorder("hover",props));
 }
 
 .c0:disabled {
@@ -3265,29 +2644,12 @@ exports[`Button with size small renders a primary variant with a label correctly
   fill: #ffffff;
 }
 
-.c0:hover,
-.c0:active,
-.c0:focus {
-  color: #ffffff;
-  background-color: #003d99;
-  cursor: pointer;
-}
-
-.c0:hover svg path,
-.c0:active svg path,
-.c0:focus svg path {
-  fill: #ffffff;
-}
-
-.c0:active,
-.c0:focus {
-  border: 1px solid #5ab2f2 !important;
-  box-shadow: 0px 0px 2px #0066ff;
-  outline: none;
-}
-
-.c0:hover {
-  border: 1px solid #00000000;
+.c0 function (_a) {
+  -webkit-var: disabled = _a.disabled;
+  -moz-var: disabled = _a.disabled;
+  -ms-var: disabled = _a.disabled;
+  var: disabled = _a.disabled;
+  return: !disabled && styled_components_1.css(templateObject_1 || (templateObject_1 = __makeTemplateObject(["\\n      :hover,\\n      :active,\\n      :focus {\\n        color: ",";\\n        background-color: ",";\\n        svg path {\\n          fill: ",";\\n        }\\n        cursor: pointer;\\n      }\\n      :active,\\n      :focus {\\n        border: "," !important;\\n        box-shadow: ",";\\n        outline: none;\\n      }\\n      :hover {\\n        border: ",";\\n      }\\n    "],["\\n      :hover,\\n      :active,\\n      :focus {\\n        color: ",";\\n        background-color: ",";\\n        svg path {\\n          fill: ",";\\n        }\\n        cursor: pointer;\\n      }\\n      :active,\\n      :focus {\\n        border: "," !important;\\n        box-shadow: ",";\\n        outline: none;\\n      }\\n      :hover {\\n        border: ",";\\n      }\\n    "])),getFontColor("hover",props),getBackgroundColor("hover",props),getFontColor("hover",props),getBorder("active",props),getBoxShadow(props),getBorder("hover",props));
 }
 
 .c0:disabled {
@@ -3343,29 +2705,12 @@ exports[`Button with size small renders with a bare icon correctly 1`] = `
   fill: #002966;
 }
 
-.c0:hover,
-.c0:active,
-.c0:focus {
-  color: #003d99;
-  background-color: #f2f2f2;
-  cursor: pointer;
-}
-
-.c0:hover svg path,
-.c0:active svg path,
-.c0:focus svg path {
-  fill: #003d99;
-}
-
-.c0:active,
-.c0:focus {
-  border: 1px solid #5ab2f2 !important;
-  box-shadow: 0px 0px 2px #0066ff;
-  outline: none;
-}
-
-.c0:hover {
-  border: 1px solid #00000000;
+.c0 function (_a) {
+  -webkit-var: disabled = _a.disabled;
+  -moz-var: disabled = _a.disabled;
+  -ms-var: disabled = _a.disabled;
+  var: disabled = _a.disabled;
+  return: !disabled && styled_components_1.css(templateObject_1 || (templateObject_1 = __makeTemplateObject(["\\n      :hover,\\n      :active,\\n      :focus {\\n        color: ",";\\n        background-color: ",";\\n        svg path {\\n          fill: ",";\\n        }\\n        cursor: pointer;\\n      }\\n      :active,\\n      :focus {\\n        border: "," !important;\\n        box-shadow: ",";\\n        outline: none;\\n      }\\n      :hover {\\n        border: ",";\\n      }\\n    "],["\\n      :hover,\\n      :active,\\n      :focus {\\n        color: ",";\\n        background-color: ",";\\n        svg path {\\n          fill: ",";\\n        }\\n        cursor: pointer;\\n      }\\n      :active,\\n      :focus {\\n        border: "," !important;\\n        box-shadow: ",";\\n        outline: none;\\n      }\\n      :hover {\\n        border: ",";\\n      }\\n    "])),getFontColor("hover",props),getBackgroundColor("hover",props),getFontColor("hover",props),getBorder("active",props),getBoxShadow(props),getBorder("hover",props));
 }
 
 .c0:disabled {
@@ -3439,29 +2784,12 @@ exports[`Button with size small renders with an icon correctly 1`] = `
   fill: #ffffff;
 }
 
-.c0:hover,
-.c0:active,
-.c0:focus {
-  color: #ffffff;
-  background-color: #003d99;
-  cursor: pointer;
-}
-
-.c0:hover svg path,
-.c0:active svg path,
-.c0:focus svg path {
-  fill: #ffffff;
-}
-
-.c0:active,
-.c0:focus {
-  border: 1px solid #5ab2f2 !important;
-  box-shadow: 0px 0px 2px #0066ff;
-  outline: none;
-}
-
-.c0:hover {
-  border: 1px solid #00000000;
+.c0 function (_a) {
+  -webkit-var: disabled = _a.disabled;
+  -moz-var: disabled = _a.disabled;
+  -ms-var: disabled = _a.disabled;
+  var: disabled = _a.disabled;
+  return: !disabled && styled_components_1.css(templateObject_1 || (templateObject_1 = __makeTemplateObject(["\\n      :hover,\\n      :active,\\n      :focus {\\n        color: ",";\\n        background-color: ",";\\n        svg path {\\n          fill: ",";\\n        }\\n        cursor: pointer;\\n      }\\n      :active,\\n      :focus {\\n        border: "," !important;\\n        box-shadow: ",";\\n        outline: none;\\n      }\\n      :hover {\\n        border: ",";\\n      }\\n    "],["\\n      :hover,\\n      :active,\\n      :focus {\\n        color: ",";\\n        background-color: ",";\\n        svg path {\\n          fill: ",";\\n        }\\n        cursor: pointer;\\n      }\\n      :active,\\n      :focus {\\n        border: "," !important;\\n        box-shadow: ",";\\n        outline: none;\\n      }\\n      :hover {\\n        border: ",";\\n      }\\n    "])),getFontColor("hover",props),getBackgroundColor("hover",props),getFontColor("hover",props),getBorder("active",props),getBoxShadow(props),getBorder("hover",props));
 }
 
 .c0:disabled {

--- a/src/components/Button/components/ButtonBase.tsx
+++ b/src/components/Button/components/ButtonBase.tsx
@@ -179,31 +179,32 @@ const getBoxShadow = (props: IStyledBaseButton) => {
   return `0px 0px 2px ${knitui.shades.blue50}`
 }
 
-const StyledButton = styled.button<IStyledBaseButton>`
+const StyledButton = styled.button<IStyledBaseButton>(
+  props => `
   display: flex;
   align-items: center;
-  font-size: ${({ customProps: { fontSize } }) => `${fontSize}rem`};
-  line-height: ${({ customProps: { lineHeight } }) => `${lineHeight}rem`};
-  padding-left: ${props => `${getLeftPadding(props)}rem`};
-  padding-right: ${props => `${getRightPadding(props)}rem`};
-  color: ${props => getFontColor("default", props)};
-  background-color: ${props => getBackgroundColor("default", props)};
-  padding-top: ${props => `${getVerticalPadding(props)}rem`};
-  padding-bottom: ${props => `${getVerticalPadding(props)}rem`};
+  font-size: ${props.customProps.fontSize}rem;
+  line-height: ${props.customProps.lineHeight}rem;
+  padding-left: ${getLeftPadding(props)}rem;
+  padding-right: ${getRightPadding(props)}rem;
+  color: ${getFontColor("default", props)};
+  background-color: ${getBackgroundColor("default", props)};
+  padding-top: ${getVerticalPadding(props)}rem;
+  padding-bottom: ${getVerticalPadding(props)}rem;
   border-radius: 0.4rem;
   border-style: none;
   box-sizing: border-box;
-  border: ${props => getBorder("default", props)};
+  border: ${getBorder("default", props)};
   span {
-    margin-right: ${props => getIconMargin(props)};
+    margin-right: ${getIconMargin(props)};
     svg path {
-      fill: ${props => getFontColor("default", props)};
+      fill: ${getFontColor("default", props)};
     }
   }
   /* Following styles are not applied when disabled
   
     Implementation Details:
-      For conditional renderering of style, have to use css tag, for more details 
+      For conditional rendering of style, have to use css tag, for more details 
       this link can be quite useful (https://stackoverflow.com/a/48502797).
 
       In one of the props, Type is needed to be defined, otherwise throwing typescript error.
@@ -214,22 +215,21 @@ const StyledButton = styled.button<IStyledBaseButton>`
       :hover,
       :active,
       :focus {
-        color: ${(props: IStyled<ButtonProps>) =>
-          getFontColor("hover", props)};
-        background-color: ${props => getBackgroundColor("hover", props)};
+        color: ${getFontColor("hover", props)};
+        background-color: ${getBackgroundColor("hover", props)};
         svg path {
-          fill: ${props => getFontColor("hover", props)};
+          fill: ${getFontColor("hover", props)};
         }
         cursor: pointer;
       }
       :active,
       :focus {
-        border: ${props => getBorder("active", props)} !important;
-        box-shadow: ${props => getBoxShadow(props)};
+        border: ${getBorder("active", props)} !important;
+        box-shadow: ${getBoxShadow(props)};
         outline: none;
       }
       :hover {
-        border: ${props => getBorder("hover", props)};
+        border: ${getBorder("hover", props)};
       }
     `}
   :disabled {
@@ -237,5 +237,6 @@ const StyledButton = styled.button<IStyledBaseButton>`
     cursor: not-allowed;
   }
 `
+)
 
 export default StyledButton

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -1,9 +1,8 @@
-import React, { SFC, ReactNode } from "react"
-import styled, { css } from "styled-components"
 import _ from "lodash"
+import React, { ReactNode } from "react"
+import styled, { css } from "styled-components"
+import { BaseComponentProps, IStyled } from "../../common/types"
 import { insertIf } from "../../common/_utils"
-import { IStyled } from "../../common/types"
-import { BaseComponentProps } from "../../common/types"
 
 export interface IInputProps
   extends React.InputHTMLAttributes<HTMLInputElement>,
@@ -117,33 +116,35 @@ const getLineHeight = (props: IStyledInput) => {
   return knitui.typography[typographySize].lineHeight
 }
 
-const StyledInput: any = styled.input<IStyledInput>`
-  height: ${props => getHeight(props)};
-  width: 100%;
-  margin: 0.4rem 0;
-  border-radius: ${({ theme: { knitui } }) => knitui.inputBorderRadius};
-  border: ${props => getInputBorder(props, "default")};
-  padding: ${props => getPadding(props)};
-  box-sizing: border-box;
-  background-color: ${({ theme: { knitui } }) => knitui.inputBgDefault};
-  color: ${({ theme: { knitui } }) => knitui.inputColor};
-  font-size: ${props => `${getFontSize(props)}rem`};
-  line-height: ${props => `${getLineHeight(props)}rem`};
-  &:hover {
-    background-color: ${({ theme: { knitui } }) => knitui.inputBgHover};
-    color: ${({ theme: { knitui } }) => knitui.inputColor};
-  }
-  &:focus,
-  &:active {
-    outline: ${({ theme: { knitui } }) => knitui.inputFocusOutline};
-    background-color: ${({ theme: { knitui } }) => knitui.inputBgFocus};
-    border: ${props => getInputBorder(props, "focus")};
-    box-shadow: ${({ theme: { knitui } }) => knitui.inputFocusBoxShadow};
-  }
-  ::placeholder {
-    color: ${({ theme: { knitui } }) => knitui.inputPlaceholderColor};
-  }
+const StyledInput: ReactNode = styled.input<IStyledInput>(props => {
+  return `
+ height: ${getHeight(props)};
+ width: 100%;
+ margin: 0.4rem 0;
+ border-radius: ${props.theme.knitui.inputBorderRadius};
+ border: ${getInputBorder(props, "default")};
+ padding: ${getPadding(props)};
+ box-sizing: border-box;
+ background-color: ${props.theme.knitui.inputBgDefault};
+ color: ${props.theme.knitui.inputColor};
+ font-size: ${getFontSize(props)}rem;
+ line-height: ${getLineHeight(props)}rem;
+ &:hover {
+   background-color: ${props.theme.knitui.inputBgHover};
+   color: ${props.theme.knitui.inputColor};
+ }
+ &:focus,
+ &:active {
+   outline: ${props.theme.knitui.inputFocusOutline};
+   background-color: ${props.theme.knitui.inputBgFocus};
+   border: ${getInputBorder(props, "focus")};
+   box-shadow: ${props.theme.knitui.inputFocusBoxShadow};
+ }
+ ::placeholder {
+   color: ${props.theme.knitui.inputPlaceholderColor};
+ }
 `
+})
 
 const AddonSpan = styled.span`
   display: flex;
@@ -174,10 +175,12 @@ const labelStyle = css`
   line-height: 1.8rem;
 `
 
-const StyledLabel = styled.label<IStyledInput>`
+const StyledLabel = styled.label<IStyledInput>(
+  props => `
   ${labelStyle}
-  color: ${props => getLabelColor(props)};
+  color: ${getLabelColor(props)};
 `
+)
 
 const NotificationContainer = styled.div`
   ${labelStyle}

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -116,8 +116,9 @@ const getLineHeight = (props: IStyledInput) => {
   return knitui.typography[typographySize].lineHeight
 }
 
-const StyledInput: ReactNode = styled.input<IStyledInput>(props => {
-  return `
+const StyledInput: any = styled.input(
+  (props: IStyledInput) =>
+    `
  height: ${getHeight(props)};
  width: 100%;
  margin: 0.4rem 0;
@@ -144,7 +145,7 @@ const StyledInput: ReactNode = styled.input<IStyledInput>(props => {
    color: ${props.theme.knitui.inputPlaceholderColor};
  }
 `
-})
+)
 
 const AddonSpan = styled.span`
   display: flex;
@@ -175,8 +176,8 @@ const labelStyle = css`
   line-height: 1.8rem;
 `
 
-const StyledLabel = styled.label<IStyledInput>(
-  props => `
+const StyledLabel = styled.label(
+  (props: IStyledInput) => `
   ${labelStyle}
   color: ${getLabelColor(props)};
 `

--- a/src/components/Label/InlineLabel.tsx
+++ b/src/components/Label/InlineLabel.tsx
@@ -1,8 +1,8 @@
 import React from "react"
 import styled from "styled-components"
 import { IStyled } from "../../common/types"
+import { getBackgroundColor, getFontColor } from "./commonUtils"
 import { InlineLabelProps, InlineLabelType } from "./types"
-import { getFontColor, getBackgroundColor } from "./commonUtils"
 
 const DEFAULT_COLOR_THEME = "neutral"
 
@@ -27,6 +27,7 @@ const geLineHeight = props => {
 }
 
 const verticalPadding = "0rem"
+
 const getHorizontalPadding = props => {
   const {
     customProps: { expanded },
@@ -34,16 +35,18 @@ const getHorizontalPadding = props => {
   return expanded ? "0.3rem" : "0rem"
 }
 
-const StyledDiv = styled.div<IStyled<InlineLabelProps>>`
+const StyledDiv = styled.div<IStyled<InlineLabelProps>>(
+  props => `
   display: inline-flex;
   align-items: center;
-  padding: ${props => `${verticalPadding} ${getHorizontalPadding(props)}`};
-  background-color: ${props => getBackgroundColor(props)};
-  color: ${props => getFontColor(props)};
-  font-size: ${props => `${getFontSize(props)}rem`};
-  line-height: ${props => `${geLineHeight(props)}rem`};
+  padding: ${verticalPadding} ${getHorizontalPadding(props)};
+  background-color: ${getBackgroundColor(props)};
+  color: ${getFontColor(props)};
+  font-size: ${getFontSize(props)}rem;
+  line-height: ${geLineHeight(props)}rem;
   box-sizing: border-box;
 `
+)
 
 const InlineLabel: InlineLabelType = ({ className, style, ...rest }) => {
   const { text } = rest

--- a/src/components/Label/Label.tsx
+++ b/src/components/Label/Label.tsx
@@ -1,11 +1,11 @@
+import _ from "lodash"
 import React, { useContext } from "react"
 import styled, { css, ThemeContext } from "styled-components"
-import _ from "lodash"
-import Icon from "../Icon"
-import { ILabel, LabelPropTypes } from "./types"
-import InlineLabel from "./InlineLabel"
 import { IStyled } from "../../common/types"
-import { getFontColor, getBackgroundColor } from "./commonUtils"
+import Icon from "../Icon"
+import { getBackgroundColor, getFontColor } from "./commonUtils"
+import InlineLabel from "./InlineLabel"
+import { ILabel, LabelPropTypes } from "./types"
 
 const DEFAULT_COLOR_THEME = "neutral"
 const INSET_BACKGROUND_COLOR = "#F7F7F7"
@@ -61,12 +61,14 @@ const verticalPadding = {
   large: 0.3,
 }
 
-const getIconPadding = (size?: string) => size === "small" ? 0.2 : 0.4
+const getIconPadding = (size?: string) => (size === "small" ? 0.2 : 0.4)
 
 const getPadding = (props: IStyledLabel) => {
   const {
     customProps: { size, expanded, outlined },
-    theme: { knitui: { defaultBorderWidth }}
+    theme: {
+      knitui: { defaultBorderWidth },
+    },
   } = props
   const defaultHorizontalPadding = expanded ? 0.9 : 0.6
   let left = defaultHorizontalPadding
@@ -99,7 +101,9 @@ const getTextRightMargin = (props: IStyledLabel) => {
 const getBorder = (props: IStyledLabel) => {
   const {
     customProps: { outlined },
-    theme: { knitui: { defaultBorderWidth }}
+    theme: {
+      knitui: { defaultBorderWidth },
+    },
   } = props
   const borderColor = outlined ? getDarkenedBorderColor(props) : "transparent"
   return `${defaultBorderWidth}rem solid ${borderColor}`
@@ -148,36 +152,50 @@ const LabelContainer = styled.div`
   position: relative;
 `
 
-const StyledDiv = styled.div<IStyledLabel>`
+const StyledDiv = styled.div<IStyledLabel>(
+  props => `
   display: inline-flex;
   align-items: center;
-  padding: ${props => getPadding(props)};
-  background-color: ${props => getBackgroundColor(props)};
-  color: ${props => getFontColor(props)};
-  font-size: ${props => `${getFontSize(props)}rem`};
-  line-height: ${props => `${geLineHeight(props)}rem`};
-  border-radius: ${props => getBorderRadius(props)};
-  border: ${props => getBorder(props)};
+  padding: ${getPadding(props)};
+  background-color: ${getBackgroundColor(props)};
+  color: ${getFontColor(props)};
+  font-size: ${`${getFontSize(props)}rem`};
+  line-height: ${`${geLineHeight(props)}rem`};
+  border-radius: ${getBorderRadius(props)};
+  border: ${getBorder(props)};
   box-sizing: border-box;
-  box-shadow: ${props => getBoxShadow(props)};
+  box-shadow: ${getBoxShadow(props)};
   overflow: hidden;
-  ${props => getInsetStyles(props)}
+  ${getInsetStyles(props)}
 `
+)
 
-const StyledTextSpan = styled.span<IStyledLabel>`
-  margin: 0rem ${props => getTextRightMargin(props)} 0rem
-    ${props => getTextLeftMargin(props)};
+const StyledTextSpan = styled.span<IStyledLabel>(
+  props => `
+  margin: 0rem ${getTextRightMargin(props)} 0rem
+    ${getTextLeftMargin(props)};
 `
+)
 
 const Label: ILabel = props => {
-
-  const labelPropKeys = ["size", "rounded", "outlined", "icons", "focus",
-        "insetColor", "text", "expanded", "colorPreset", "customColor", "customFontColor"]
+  const labelPropKeys = [
+    "size",
+    "rounded",
+    "outlined",
+    "icons",
+    "focus",
+    "insetColor",
+    "text",
+    "expanded",
+    "colorPreset",
+    "customColor",
+    "customFontColor",
+  ]
 
   const labelProps = _.pick(props, labelPropKeys)
   const otherProps = _.omit(props, labelPropKeys)
 
-const { text, insetColor, icons } = labelProps
+  const { text, insetColor, icons } = labelProps
   /**
    * Styled Component theme should be needed here, because getFontColor take theme
    * as argument
@@ -216,10 +234,7 @@ const { text, insetColor, icons } = labelProps
   //For styled components, we separate the props that are to be loaded on the DOM
   return (
     <LabelContainer>
-      <StyledDiv
-        {...scProps}
-        {...otherProps}
-        insetColor={insetColor}>
+      <StyledDiv {...scProps} {...otherProps} insetColor={insetColor}>
         {renderLeftIcon()}
         <StyledTextSpan {...scProps}>{text}</StyledTextSpan>
         {renderRightIcon()}

--- a/src/components/Label/__tests__/__snapshots__/Label.test.tsx.snap
+++ b/src/components/Label/__tests__/__snapshots__/Label.test.tsx.snap
@@ -301,7 +301,7 @@ exports[`Label inset 1`] = `
   bottom: 0;
   left: 0;
   width: 0.3rem;
-  background: #4267B2;
+  background: ,#4267B2,;
   border-radius: 0.2rem 0 0 0.2rem;
 }
 
@@ -363,7 +363,7 @@ exports[`Label inset with custom color 1`] = `
   bottom: 0;
   left: 0;
   width: 0.3rem;
-  background: #4267B2;
+  background: ,#4267B2,;
   border-radius: 0.2rem 0 0 0.2rem;
 }
 

--- a/src/components/Modal/components/Header.tsx
+++ b/src/components/Modal/components/Header.tsx
@@ -20,8 +20,7 @@ const getMinHeight = (props: IStyledHeaderProps) => {
   return lineHeight + 2 * VERTICAL_PADDING
 }
 
-const Container = styled.div<IStyledHeaderProps>(
-  props => `
+const Container = styled.div<IStyledHeaderProps>`
   display: flex;
   padding: ${({ theme: { knitui } }) =>
     `${knitui.modalHeaderPadding.vertical}rem ${knitui.modalHeaderPadding.horizontal}rem`};
@@ -31,9 +30,8 @@ const Container = styled.div<IStyledHeaderProps>(
     noFill ? "none" : knitui.chromaPalette.Neutral10};
   border-bottom: ${({ customProps: { noFill }, theme: { knitui } }) =>
     noFill ? knitui.modalBorder : "none"};
-  min-height: ${getMinHeight(props)}rem};
+  min-height: ${props => getMinHeight(props)}rem};
 `
-)
 
 const Header: React.FC<HeaderProps> = props => {
   const { children } = props

--- a/src/components/Modal/components/Header.tsx
+++ b/src/components/Modal/components/Header.tsx
@@ -20,7 +20,8 @@ const getMinHeight = (props: IStyledHeaderProps) => {
   return lineHeight + 2 * VERTICAL_PADDING
 }
 
-const Container = styled.div<IStyledHeaderProps>`
+const Container = styled.div<IStyledHeaderProps>(
+  props => `
   display: flex;
   padding: ${({ theme: { knitui } }) =>
     `${knitui.modalHeaderPadding.vertical}rem ${knitui.modalHeaderPadding.horizontal}rem`};
@@ -30,8 +31,9 @@ const Container = styled.div<IStyledHeaderProps>`
     noFill ? "none" : knitui.chromaPalette.Neutral10};
   border-bottom: ${({ customProps: { noFill }, theme: { knitui } }) =>
     noFill ? knitui.modalBorder : "none"};
-  min-height: ${props => `${getMinHeight(props)}rem`};
+  min-height: ${getMinHeight(props)}rem};
 `
+)
 
 const Header: React.FC<HeaderProps> = props => {
   const { children } = props

--- a/src/components/Modal/components/Main.tsx
+++ b/src/components/Modal/components/Main.tsx
@@ -12,11 +12,13 @@ const getPadding = (props: IStyledDialog) => {
     : `${knitui.modalPadding.vertical}rem ${knitui.modalPadding.horizontal}rem`
 }
 
-const StyledMain = styled.div<IStyledDialog>`
-  padding: ${props => getPadding(props)};
+const StyledMain = styled.div<IStyledDialog>(
+  props => `
+  padding: ${getPadding(props)};
   overflow-y: auto;
   flex: 1 1 auto;
 `
+)
 
 const Main: any = React.forwardRef(
   (props: { customProps?: {}; children: React.ReactNode }, ref) => {

--- a/src/components/Modal/components/Main.tsx
+++ b/src/components/Modal/components/Main.tsx
@@ -12,8 +12,8 @@ const getPadding = (props: IStyledDialog) => {
     : `${knitui.modalPadding.vertical}rem ${knitui.modalPadding.horizontal}rem`
 }
 
-const StyledMain = styled.div<IStyledDialog>(
-  props => `
+const StyledMain = styled.div(
+  (props: IStyledDialog) => `
   padding: ${getPadding(props)};
   overflow-y: auto;
   flex: 1 1 auto;

--- a/src/components/Modal/variants/styledComponents.ts
+++ b/src/components/Modal/variants/styledComponents.ts
@@ -20,8 +20,8 @@ export const BaseLayout = styled.div`
   min-height: inherit;
 `
 
-export const Layout = styled.div<IStyledPanelModal>(
-  props => `
+export const Layout = styled.div(
+  (props: IStyledPanelModal) => `
   display: flex;
   flex-direction: row;
   align-items: stretch;
@@ -32,8 +32,8 @@ export const Layout = styled.div<IStyledPanelModal>(
 )
 
 // Applies to left and right panels only
-export const PanelSection = styled.div<IStyledPanelModal>(
-  props => `
+export const PanelSection = styled.div(
+  (props: IStyledPanelModal) => `
   width: 21rem;
   flex-shrink: 0;
   ${getPanelBorder(props)}
@@ -48,7 +48,7 @@ export const Content = styled.div<IStyledModal>`
 `
 
 export const VerticalLayoutContent = styled(Content)(
-  props => `
+  (props: IStyledModal) => `
   max-height: ${props.customProps.maxContentHeight};
   min-height: ${props.customProps.minContentHeight};
 `

--- a/src/components/Modal/variants/styledComponents.ts
+++ b/src/components/Modal/variants/styledComponents.ts
@@ -1,8 +1,11 @@
 import styled from "styled-components"
-import { IStyledPanelModal, IStyledModal } from "./types"
+import { IStyledModal, IStyledPanelModal } from "./types"
 
 const getPanelBorder = (props: IStyledPanelModal) => {
-  const { customProps: { location }, theme: { knitui }} = props
+  const {
+    customProps: { location },
+    theme: { knitui },
+  } = props
   if (location === "right") {
     return `border-left: ${knitui.modalBorder};`
   }
@@ -17,22 +20,26 @@ export const BaseLayout = styled.div`
   min-height: inherit;
 `
 
-export const Layout = styled.div<IStyledPanelModal>`
+export const Layout = styled.div<IStyledPanelModal>(
+  props => `
   display: flex;
   flex-direction: row;
   align-items: stretch;
   flex: 1 1 auto;
-  max-height: ${props => props.customProps.maxContentHeight};
-  min-height: ${props => props.customProps.minContentHeight};
+  max-height: ${props.customProps.maxContentHeight};
+  min-height: ${props.customProps.minContentHeight};
 `
+)
 
 // Applies to left and right panels only
-export const PanelSection = styled.div<IStyledPanelModal>`
+export const PanelSection = styled.div<IStyledPanelModal>(
+  props => `
   width: 21rem;
   flex-shrink: 0;
-  ${props => getPanelBorder(props)}
+  ${getPanelBorder(props)}
   overflow-y: auto;
 `
+)
 
 export const Content = styled.div<IStyledModal>`
   display: flex;
@@ -40,7 +47,9 @@ export const Content = styled.div<IStyledModal>`
   flex-grow: 1;
 `
 
-export const VerticalLayoutContent = styled(Content)`
-  max-height: ${props => props.customProps.maxContentHeight};
-  min-height: ${props => props.customProps.minContentHeight};
+export const VerticalLayoutContent = styled(Content)(
+  props => `
+  max-height: ${props.customProps.maxContentHeight};
+  min-height: ${props.customProps.minContentHeight};
 `
+)

--- a/src/components/Radio/Interface.ts
+++ b/src/components/Radio/Interface.ts
@@ -16,6 +16,7 @@ export interface RadioWrapperProps {
   value?: any
   setValue?: (e) => void | any
   size?: string
+  theme?: object
 }
 
 type size = "small" | "medium"

--- a/src/components/Radio/styledRadio.tsx
+++ b/src/components/Radio/styledRadio.tsx
@@ -5,8 +5,7 @@ import { RadioWrapperProps } from "./Interface"
 const isSmall = size => size === "small"
 const isDisabled = props => props.disabled
 
-export const StyledRadioRoot = styled.span<RadioWrapperProps>(
-  props => `
+export const StyledRadioRoot = styled.span<RadioWrapperProps>`
   &.knit-radio {
     white-space: nowrap;
     outline: none;
@@ -14,7 +13,7 @@ export const StyledRadioRoot = styled.span<RadioWrapperProps>(
     position: relative;
 
     & + span {
-      cursor: ${isDisabled(props) ? "not-allowed" : "pointer"};
+      cursor: ${props => (isDisabled(props) ? "not-allowed" : "pointer")};
       margin-left: 10px;
     }
 
@@ -49,7 +48,6 @@ export const StyledRadioRoot = styled.span<RadioWrapperProps>(
     }
   }
 `
-)
 
 export const StyledRadioInner = styled.span<{
   size: string | undefined

--- a/src/components/Radio/styledRadio.tsx
+++ b/src/components/Radio/styledRadio.tsx
@@ -1,11 +1,12 @@
 import styled from "styled-components"
-import { Neutral0, Neutral50, Blue100 } from "../../common/styles/palette"
+import { Blue100, Neutral0, Neutral50 } from "../../common/styles/palette"
 import { RadioWrapperProps } from "./Interface"
 
 const isSmall = size => size === "small"
 const isDisabled = props => props.disabled
 
-export const StyledRadioRoot = styled.span<RadioWrapperProps>`
+export const StyledRadioRoot = styled.span<RadioWrapperProps>(
+  props => `
   &.knit-radio {
     white-space: nowrap;
     outline: none;
@@ -13,7 +14,7 @@ export const StyledRadioRoot = styled.span<RadioWrapperProps>`
     position: relative;
 
     & + span {
-      cursor: ${props => (isDisabled(props) ? "not-allowed" : "pointer")};
+      cursor: ${isDisabled(props) ? "not-allowed" : "pointer"};
       margin-left: 10px;
     }
 
@@ -48,6 +49,7 @@ export const StyledRadioRoot = styled.span<RadioWrapperProps>`
     }
   }
 `
+)
 
 export const StyledRadioInner = styled.span<{
   size: string | undefined


### PR DESCRIPTION
* Looks more simple and cleaner
* Saves some memory as a new function won't be created during compilation
*  Ton of redundant props removal