### PR TITLE
tabs onChange improvements & adding api parameter

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
   "dependencies": {
     "@types/styled-components": "^4.1.14",
     "@types/uuid": "^3.4.5",
+    "array-move": "^2.2.1",
     "chroma-js": "^2.0.3",
     "rc-dialog": "^7.3.1",
     "rc-switch": "^1.9.0",

--- a/src/components/Tabs/TabItem.tsx
+++ b/src/components/Tabs/TabItem.tsx
@@ -84,7 +84,7 @@ export const TabItem = SortableElement(
       role: "tab",
       "aria-controls": "tabpanel-id",
       children: props.tab,
-      onClick: () => onChange(props.tabKey),
+      onClick: () => !isActive && onChange(props.tabKey),
     })
     const showVBar = itemIndex + 1 !== activeKeyIndex && !isActive
     let styles = getTabContainerStyle(

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -1,6 +1,6 @@
 import React, { Children, useState, useEffect, useRef } from "react"
 import styled, { css } from "styled-components"
-import { arrayMove } from "react-sortable-hoc"
+import arrayMove from "array-move"
 import {
   TabsProps,
   TabWrapperInterface,
@@ -149,6 +149,7 @@ const Tabs: TabWrapperInterface<TabsProps> = ({ children, ...tabProps }) => {
     onChange = internalState[1],
     onAddTab,
     onOrderChange,
+    pressDelay = 100,
   } = tabProps
   const [childrenArray, setChildrenArray] = useState([])
   const [activeKeyIndex, setActiveKeyIndex] = useState(0)
@@ -265,7 +266,7 @@ const Tabs: TabWrapperInterface<TabsProps> = ({ children, ...tabProps }) => {
               onSortEnd={onSortEnd}
               axis={"x"}
               lockAxis="x"
-              pressDelay={10}
+              pressDelay={pressDelay}
               onChange={onChange}
               activeTabFlags={activeTabFlags}
               itemRef={itemRef}

--- a/src/components/Tabs/types.ts
+++ b/src/components/Tabs/types.ts
@@ -11,6 +11,7 @@ export interface TabsProps extends BaseComponentProps {
   activeKey?: string
   hideAdd?: boolean
   size?: "default" | "medium"
+  pressDelay?: number
   onChange?: (activeKey: string) => void
   onAddTab: () => void
   onOrderChange?: (onOrderChnageParams: onOrderChnageParams) => any

--- a/yarn.lock
+++ b/yarn.lock
@@ -2569,6 +2569,11 @@ array-map@~0.0.0:
   resolved "https://registry.yarnpkg.com/array-map/-/array-map-0.0.0.tgz#88a2bab73d1cf7bcd5c1b118a003f66f665fa662"
   integrity sha1-iKK6tz0c97zVwbEYoAP2b2ZfpmI=
 
+array-move@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/array-move/-/array-move-2.2.1.tgz#16d5b68cb949c43e8821d63e4622f3a3336f254d"
+  integrity sha512-qQpEHBnVT6HAFgEVUwRdHVd8TYJThrZIT5wSXpEUTPwBaYhPLclw12mEpyUvRWVdl1VwPOqnIy6LqTFN3cSeUQ==
+
 array-reduce@~0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/array-reduce/-/array-reduce-0.0.0.tgz#173899d3ffd1c7d9383e4479525dbe278cab5f2b"


### PR DESCRIPTION
     - onClick called even when clicked on active tab, added a flag
     - pressDelay still not standarized, currently making a props to tweak it from outside as require in use-case
     - array-move package for changing order, because sortable-hoc arrayMove is getting deprecated