### PR TITLE
Tab component CSS fixes

### DIFF
--- a/src/common/styles/GlobalStyles.tsx
+++ b/src/common/styles/GlobalStyles.tsx
@@ -46,6 +46,10 @@ const GlobalStyles = createGlobalStyle`
       padding: 0;
   }
 
+  body {
+    overscroll-behavior-x: none; /* Prevent the page redirection on swipe */
+  }
+
   ul,
   ol {
       list-style: none;

--- a/src/components/Tabs/TabItem.tsx
+++ b/src/components/Tabs/TabItem.tsx
@@ -11,6 +11,7 @@ const VerticalBar = styled.div`
   top: 50%;
   right: 0;
   transform: translateY(-50%);
+  pointer-events: none;
 `
 
 type TabItemType = {
@@ -33,18 +34,18 @@ const getTabContainerStyle = (
 ) => {
   let styles: React.CSSProperties = { position: "relative", zIndex: 99 }
   if (activeKeyIndex === itemIndex) {
-    styles = { position: "relative", zIndex: 100 }
+    styles = { position: "relative", zIndex: 101 }
   }
   if (activeTabFlags.left && activeKeyIndex === itemIndex) {
     styles = {
       position: "absolute",
-      zIndex: 100,
+      zIndex: 101,
     }
   } else if (activeTabFlags.right && activeKeyIndex === itemIndex) {
     styles = {
       position: "absolute",
-      zIndex: 100,
-      right: 18,
+      zIndex: 101,
+      right: 30,
     }
   }
   const current = itemRef.current

--- a/src/components/Tabs/Tabs.stories.tsx
+++ b/src/components/Tabs/Tabs.stories.tsx
@@ -22,75 +22,119 @@ stories
   })
   .add("basic", () => {
     return (
-      <div
-        style={{
-          border: "1px solid lightgray",
-          height: "360px",
-          width: "800px",
-          fontSize: 14,
-        }}>
-        <Tabs onAddTab={() => alert("callback for create add")}>
-          <TabPanel tab="Tab 1" tabKey="tab-1">
-            tab 1 content here
-          </TabPanel>
-          <TabPanel tab="Tab 2" tabKey="tab-2">
-            tab 2 content here
-          </TabPanel>
-          <TabPanel tab="Tab 3" tabKey="tab-3">
-            tab 3 content here
-          </TabPanel>
-          <TabPanel tab="Tab 4" tabKey="tab-4">
-            tab 4 content here
-          </TabPanel>
-          <TabPanel tab="Tab 5" tabKey="tab-5">
-            tab 5 content here
-          </TabPanel>
-          <TabPanel tab="Tab 31" tabKey="tab-31">
-            tab 31 content here
-          </TabPanel>
-          <TabPanel tab="Tab 32" tabKey="tab-312">
-            tab 32 content here
-          </TabPanel>
-          <TabPanel tab="Tab 3f" tabKey="tab-3f">
-            tab 3f content here
-          </TabPanel>
-          <TabPanel tab="Tab f" tabKey="tab-3v">
-            tab 3 content here
-          </TabPanel>
-          <TabPanel tab="Tab g" tabKey="tab-g">
-            tab 3 content here
-          </TabPanel>
-          <TabPanel tab="Tab 12" tabKey="tab-15">
-            tab 1 content here
-          </TabPanel>
-          <TabPanel tab="Tab 22" tabKey="tab-25">
-            tab 2 content here
-          </TabPanel>
-          <TabPanel tab="Tab 32" tabKey="tab-35">
-            tab 3 content here
-          </TabPanel>
-          <TabPanel tab="Tab 42" tabKey="tab-45">
-            tab 4 content here
-          </TabPanel>
-          <TabPanel tab="Tab 52" tabKey="tab-55">
-            tab 5 content here
-          </TabPanel>
-          <TabPanel tab="Tab 12" tabKey="tab-16">
-            tab 1 content here
-          </TabPanel>
-          <TabPanel tab="Tab 22" tabKey="tab-26">
-            tab 2 content here
-          </TabPanel>
-          <TabPanel tab="Tab 32" tabKey="tab-36">
-            tab 3 content here
-          </TabPanel>
-          <TabPanel tab="Tab 42" tabKey="tab-46">
-            tab 4 content here
-          </TabPanel>
-          <TabPanel tab="Tab 52" tabKey="tab-56">
-            tab 5 content here
-          </TabPanel>
-        </Tabs>
+      <div>
+        <div
+          style={{
+            border: "1px solid lightgray",
+            height: "360px",
+            width: "100%",
+            fontSize: 14,
+            marginBottom: 20,
+            padding: 20,
+          }}>
+          <Tabs onAddTab={() => alert("callback for create add")}>
+            <TabPanel tab="Tab 1" tabKey="tab-1">
+              tab 1 content here
+            </TabPanel>
+            <TabPanel tab="Tab 2" tabKey="tab-2">
+              tab 2 content here
+            </TabPanel>
+            <TabPanel tab="Tab 3" tabKey="tab-3">
+              tab 3 content here
+            </TabPanel>
+            <TabPanel tab="Tab 4" tabKey="tab-4">
+              tab 4 content here
+            </TabPanel>
+            <TabPanel tab="Tab 5" tabKey="tab-5">
+              tab 5 content here
+            </TabPanel>
+            <TabPanel tab="Tab 6" tabKey="tab-6">
+              tab 6 content here
+            </TabPanel>
+            <TabPanel tab="Tab 7" tabKey="tab-7">
+              tab 7 content here
+            </TabPanel>
+            <TabPanel tab="Tab 8" tabKey="tab-8">
+              tab 8 content here
+            </TabPanel>
+            <TabPanel tab="Tab 9" tabKey="tab-9">
+              tab 9 content here
+            </TabPanel>
+            <TabPanel tab="Tab 10" tabKey="tab-10">
+              tab 10 content here
+            </TabPanel>
+            <TabPanel tab="Tab 11" tabKey="tab-11">
+              tab 11 content here
+            </TabPanel>
+            <TabPanel tab="Tab 12" tabKey="tab-12">
+              tab 12 content here
+            </TabPanel>
+            <TabPanel tab="Tab 13" tabKey="tab-13">
+              tab 13 content here
+            </TabPanel>
+            <TabPanel tab="Tab 14" tabKey="tab-14">
+              tab 14 content here
+            </TabPanel>
+            <TabPanel tab="Tab 15" tabKey="tab-15">
+              tab 15 content here
+            </TabPanel>
+            <TabPanel tab="Tab 16" tabKey="tab-16">
+              tab 16 content here
+            </TabPanel>
+            <TabPanel tab="Tab 17" tabKey="tab-17">
+              tab 17 content here
+            </TabPanel>
+            <TabPanel tab="Tab 18" tabKey="tab-18">
+              tab 18 content here
+            </TabPanel>
+            <TabPanel tab="Tab 19" tabKey="tab-19">
+              tab 19 content here
+            </TabPanel>
+            <TabPanel tab="Tab 20" tabKey="tab-20">
+              tab 20 content here
+            </TabPanel>
+          </Tabs>
+        </div>
+        <div
+          style={{
+            border: "1px solid lightgray",
+            height: "360px",
+            width: "100%",
+            fontSize: 14,
+          }}>
+          <Tabs onAddTab={() => alert("callback for create add")}>
+            <TabPanel tab="Tab 1" tabKey="tab-1">
+              tab 1 content here
+            </TabPanel>
+            <TabPanel tab="Tab 2" tabKey="tab-2">
+              tab 2 content here
+            </TabPanel>
+            <TabPanel tab="Tab 3" tabKey="tab-3">
+              tab 3 content here
+            </TabPanel>
+            <TabPanel tab="Tab 4" tabKey="tab-4">
+              tab 4 content here
+            </TabPanel>
+            <TabPanel tab="Tab 5" tabKey="tab-5">
+              tab 5 content here
+            </TabPanel>
+            <TabPanel tab="Tab 31" tabKey="tab-31">
+              tab 31 content here
+            </TabPanel>
+            <TabPanel tab="Tab 32" tabKey="tab-312">
+              tab 32 content here
+            </TabPanel>
+            <TabPanel tab="Tab 3f" tabKey="tab-3f">
+              tab 3f content here
+            </TabPanel>
+            <TabPanel tab="Tab f" tabKey="tab-3v">
+              tab 3 content here
+            </TabPanel>
+            <TabPanel tab="Tab g" tabKey="tab-g">
+              tab 3 content here
+            </TabPanel>
+          </Tabs>
+        </div>
       </div>
     )
   })

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -11,6 +11,15 @@ import { Button, Icon } from ".."
 import { TabsList } from "./TabsList"
 import { getThemeColor, getOSName } from "../../common/_utils"
 
+const ButtonWrapper = styled(Button)`
+  border-radius: 4px 4px 0 0;
+  :hover,
+  :focus,
+  :active {
+    background: #efe9dc;
+  }
+`
+
 const TabsWrapper = styled.div<{ hideTabContent: boolean }>`
   height: ${({ hideTabContent }) => (hideTabContent ? "auto" : "100%")};
   width: 100%;
@@ -19,7 +28,6 @@ const TabsWrapper = styled.div<{ hideTabContent: boolean }>`
 const TabsPanelWrapper = styled.div`
   display: flex;
   background: ${props => getThemeColor(props, "Beige10")};
-  padding: 0 50px;
 `
 
 const OverflowWrapper = styled.div`
@@ -50,7 +58,7 @@ const BlurElement = styled.div<{
     ${props => getThemeColor(props, "Beige10")}FF,
     ${props => getThemeColor(props, "Beige10")}00
   );
-  z-index: 9;
+  z-index: 100;
   visibility: ${props => (props.visible ? "visible" : "hidden")};
   pointer-events: none;
 `
@@ -59,21 +67,47 @@ const IconWrapper = styled.div<{ visible: boolean }>`
   display: flex;
   justify-content: center;
   align-items: center;
+  transition: visibility 250ms ease, width 150ms linear;
   visibility: ${props => (props.visible ? "visible" : "hidden")};
+  width: ${props => (props.visible ? "30px" : "0")};
   cursor: pointer;
+  z-index: 100;
+
+  :hover,
+  :focus,
+  :active {
+    background: #efe9dc;
+  }
 `
 
 const TabPanel = styled.button<{ active?: boolean }>`
-  background: ${props => (props.active ? "#FFFFFF" : "none")};
-  border: none;
+  background: ${props =>
+    props.active ? getThemeColor(props, "Neutral0") : "none"};
+  color: ${props =>
+    props.active
+      ? getThemeColor(props, "Neutral90")
+      : getThemeColor(props, "Neutral50")};
+  border: 1px solid transparent;
   border-top: ${props =>
     props.active ? "2px solid #D8C9A7" : "2px solid transparent"};
   padding: 4px 14px;
-  border-radius: 2px 2px 0px 0px;
+  border-radius: 4px 4px 0px 0px;
   min-width: 80px;
   line-height: 20px;
   font-size: 14px;
   cursor: pointer;
+  margin-right: 1px;
+
+  :hover {
+    background: ${props => (props.active ? "#FFFFFF" : "#efe9dc")};
+  }
+
+  :active,
+  :focus {
+    z-index: 101 !important;
+    outline-color: ${props => getThemeColor(props, "Azure80")};
+    border-color: ${props => getThemeColor(props, "Azure80")} auto 1px;
+  }
 `
 
 const TabContentWrapper = styled.div`
@@ -279,14 +313,14 @@ const Tabs: TabWrapperInterface<TabsProps> = ({ children, ...tabProps }) => {
             visible={showRightBlur}
             dir="right"
             style={{
-              right: 18,
+              right: 28,
             }}
           />
           <IconWrapper visible={showRightArrow} onClick={handleScrollRight}>
             <Icon type="oKeyboardArrowRight" size="18px" fill="#000000" />
           </IconWrapper>
         </OverflowWrapper>
-        <Button
+        <ButtonWrapper
           onClick={onAddTab}
           icon="oAdd"
           kind="primary"

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -96,7 +96,7 @@ const TabPanel = styled.button<{ active?: boolean }>`
   line-height: 20px;
   font-size: 14px;
   cursor: pointer;
-  margin-right: 1px;
+  margin-right: 1px; /* To prevent focus outline overlapping with divider */
 
   :hover {
     background: ${props => (props.active ? "#FFFFFF" : "#efe9dc")};

--- a/src/components/Tabs/TabsList.tsx
+++ b/src/components/Tabs/TabsList.tsx
@@ -29,6 +29,7 @@ export const TabsList = SortableContainer(
       <div
         style={{
           display: "flex",
+          whiteSpace: "nowrap",
         }}>
         <div />
         {items.map((value, index) => (


### PR DESCRIPTION
- Fixes the z-index of active tab, blurElements, Arrow buttons . Unfortunately, it still uses z-index in magnitude of 99, 100, 101.
- Added transitions for better experience
- Fixes the color, states of the icon buttons
- Removes the padding of 50px defined in tab wrapper (it should be provided by the component where tab is being consumed)
- Prevents the redirection of pages on swipe(Mac)
- Prevents word break by default
- Adds hover state for the inactive tab items
- other minor style polishing