### PR TITLE
tab's sticky behaviour fixes & refactor

### DIFF
--- a/src/components/Tabs/TabItem.tsx
+++ b/src/components/Tabs/TabItem.tsx
@@ -1,48 +1,8 @@
 import React from "react"
 import { SortableElement, SortableHandle } from "react-sortable-hoc"
-import styled from "styled-components"
+import { VerticalBar, DragIcon } from "./styles"
 import { getTabContainerStyle } from "./utils"
-import { activeTabFlagsInterface } from "./types"
-import { Icon } from "../"
-import { getThemeColor } from "../../common/_utils"
-const VerticalBar = styled.div`
-  height: 14px;
-  width: 0px;
-  position: absolute;
-  border-right: 1px solid #cccccc;
-  top: 50%;
-  right: 0;
-  transform: translateY(-50%);
-  pointer-events: none;
-`
-
-type TabItemType = {
-  value: any
-  onChange: (activeKey: string) => void
-  activeKey: string | null
-  activeKeyIndex: number
-  itemIndex: number
-  activeTabFlags: activeTabFlagsInterface
-  itemRef: React.RefObject<HTMLDivElement>
-  activeNxtRef: React.RefObject<HTMLDivElement>
-  activePrevRef: React.RefObject<HTMLDivElement>
-  dragHandle: boolean
-  dragHandleElement: React.FC<any> | null
-  readOnly: boolean
-}
-
-const DragIcon = styled(Icon)`
-  cursor: grab;
-  & svg {
-    fill: ${props => getThemeColor(props, "Neutral45")};
-  }
-  margin-right: 0.4rem;
-  & svg :hover,
-  & svg :active,
-  & svg :focus {
-    fill: #000000;
-  }
-`
+import { TabItemType } from "./types"
 
 export const TabDragElement = SortableHandle(({ children }) => children)
 
@@ -85,7 +45,7 @@ export const TabItem = SortableElement(
       onClick: () => !isActive && onChange(props.tabKey),
     })
     const showVBar = itemIndex + 1 !== activeKeyIndex && !isActive
-    let styles = getTabContainerStyle(
+    const styles = getTabContainerStyle(
       activeTabFlags,
       activeKeyIndex,
       itemIndex,

--- a/src/components/Tabs/TabsList.tsx
+++ b/src/components/Tabs/TabsList.tsx
@@ -1,21 +1,8 @@
-import React, { ReactNode, ReactElement } from "react"
+import React from "react"
 import { SortableContainer } from "react-sortable-hoc"
 import { TabItem } from "./TabItem"
-import { activeTabFlagsInterface } from "./types"
-
-type TabsListProps = {
-  items: Array<ReactNode>
-  onChange: (activeKey: string) => void
-  activeKey: string
-  activeKeyIndex: number
-  activeTabFlags: activeTabFlagsInterface
-  itemRef: React.RefObject<HTMLDivElement>
-  activeNxtRef: React.RefObject<HTMLDivElement>
-  activePrevRef: React.RefObject<HTMLDivElement>
-  dragHandle: boolean
-  dragHandleElement: React.FC<any> | null
-  readOnly: boolean
-}
+import { OverflowContainer } from "./styles"
+import { TabsListProps } from "./types"
 
 export const TabsList = SortableContainer(
   ({
@@ -30,13 +17,10 @@ export const TabsList = SortableContainer(
     dragHandle,
     dragHandleElement,
     readOnly,
+    listRef,
   }: TabsListProps) => {
     return (
-      <div
-        style={{
-          display: "flex",
-          whiteSpace: "nowrap",
-        }}>
+      <OverflowContainer ref={listRef}>
         <div />
         {items.map((value, index) => (
           <TabItem
@@ -56,7 +40,7 @@ export const TabsList = SortableContainer(
             activePrevRef={activePrevRef}
           />
         ))}
-      </div>
+      </OverflowContainer>
     )
   }
 )

--- a/src/components/Tabs/styles.tsx
+++ b/src/components/Tabs/styles.tsx
@@ -1,0 +1,183 @@
+import { RefObject } from "react"
+import styled, { createGlobalStyle } from "styled-components"
+import { Button, Icon } from ".."
+import { getThemeColor, getOSName } from "../../common/_utils"
+
+/* The tab being dragged is appended to the body, hence it's styles need to be at global scope*/
+
+export const GlobalStyle = createGlobalStyle`
+.knitui-tabs-helper:not(#knit-active-tab) {
+  background: ${props => getThemeColor(props, "Beige10")};
+  
+  &:before {
+    content: "";
+    position: absolute;
+    left: 0;
+    top: 50%;
+    transform: translateY(-50%);
+    height: 1.4rem;
+    width: 1px;
+    background: ${props => getThemeColor(props, "Neutral40")};
+  }
+}
+
+.knitui-tabs-helper {
+  white-space: nowrap;
+}
+`
+
+export const ButtonWrapper = styled(Button)`
+  border-radius: 4px 4px 0 0;
+  :hover,
+  :focus,
+  :active {
+    background: #efe9dc;
+  }
+`
+
+export const TabsWrapper = styled.div<{ hideTabContent: boolean }>`
+  height: ${({ hideTabContent }) => (hideTabContent ? "auto" : "100%")};
+  width: 100%;
+`
+
+export const TabsPanelWrapper = styled.div`
+  display: flex;
+  background: ${props => getThemeColor(props, "Beige10")};
+`
+
+const getActiveTabHeight = props => {
+  return "100%"
+
+  /**
+   * Idea was to assign height as much as active tab but during drag tab
+   * height has extra 2px which causing recursive increase of OverflowWrapper's height.
+   * Have to find work-around for this.
+   */
+  return props.activeTabRef.current
+    ? `${props.activeTabRef.current.getBoundingClientRect().height}px`
+    : "100%"
+}
+
+export const OverflowWrapper = styled.div<{
+  activeTabRef: RefObject<HTMLDivElement>
+}>`
+  /**
+   * Height needed to taken from ref because in some cases like in MacOS Mojave 
+   * irrespective of browser & it's version, padding-bottom still visible.
+   */
+  height: ${props => getActiveTabHeight(props)};
+  overflow: hidden;
+  position: relative;
+  display: flex;
+`
+
+export const BlurElement = styled.div<{ dir: string; visible: boolean }>`
+  width: 80px;
+  height: 100%;
+  position: absolute;
+  background: linear-gradient(
+    to ${props => (props.dir === "left" ? "right" : "left")},
+    ${props => getThemeColor(props, "Beige10")}FF,
+    ${props => getThemeColor(props, "Beige10")}00
+  );
+  z-index: 100;
+  visibility: ${props => (props.visible ? "visible" : "hidden")};
+  pointer-events: none;
+`
+
+export const IconWrapper = styled.div<{ visible: boolean }>`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  transition: visibility 250ms ease, width 150ms linear;
+  visibility: ${props => (props.visible ? "visible" : "hidden")};
+  width: ${props => (props.visible ? "30px" : "0")};
+  cursor: pointer;
+  z-index: 100;
+
+  :hover,
+  :focus,
+  :active {
+    background: #efe9dc;
+  }
+`
+
+export const TabPanel = styled.button<{
+  active?: boolean
+  dragHandle?: boolean
+}>`
+  display: flex;
+  flex-wrap: nowrap;
+  justify-content: center;
+  align-items: center;
+  word-wrap: none;
+
+  background: ${props =>
+    props.active ? getThemeColor(props, "Neutral0") : "none"};
+  color: ${props =>
+    props.active
+      ? getThemeColor(props, "Neutral90")
+      : getThemeColor(props, "Neutral50")};
+  border: 2px solid transparent;
+  border-top: ${props =>
+    props.active ? "2px solid #D8C9A7" : "2px solid transparent"};
+  padding: 4px 14px;
+  border-radius: 4px 4px 0px 0px;
+  min-width: 80px;
+  line-height: 20px;
+  font-size: 14px;
+  cursor: ${props => (props.dragHandle && props.active ? "auto" : "pointer")};
+
+  /* To prevent focus outline overlapping with divider */
+  margin-right: ${props => (props.active ? "0" : "1px")};
+
+  :hover {
+    background: ${props => (props.active ? "#FFFFFF" : "#efe9dc")};
+  }
+
+  :active,
+  :focus {
+    z-index: 101 !important;
+    outline-color: ${props => getThemeColor(props, "Azure80")};
+    border-color: ${props => getThemeColor(props, "Azure80")} auto 1px;
+  }
+`
+
+export const TabContentWrapper = styled.div`
+  width: 100%;
+`
+
+export const OverflowContainer = styled.div`
+  display: flex;
+  align-items: center;
+  white-space: nowrap;
+  width: 100%;
+  overflow: scroll hidden;
+  padding-bottom: ${getOSName() !== "MacOS" ? "0px" : "17px"};
+  margin-bottom: -17px;
+  box-sizing: content-box;
+`
+
+export const DragIcon = styled(Icon)`
+  cursor: grab;
+  & svg {
+    fill: ${props => getThemeColor(props, "Neutral45")};
+  }
+  margin-right: 0.4rem;
+  & svg :hover,
+  & svg :active,
+  & svg :focus {
+    fill: #000000;
+  }
+`
+
+export const VerticalBar = styled.div`
+  height: 14px;
+  width: 0px;
+  position: absolute;
+  border-right: 1px solid #cccccc;
+  top: 50%;
+  right: 0;
+  transform: translateY(-50%);
+  pointer-events: none;
+`

--- a/src/components/Tabs/types.ts
+++ b/src/components/Tabs/types.ts
@@ -41,7 +41,37 @@ export interface TabWrapperInterface<T> extends React.FC<T> {
   TabPanel: any
 }
 
-export interface activeTabFlagsInterface {
+export interface ActiveTabFlagsInterface {
   left: boolean
   right: boolean
+}
+
+export type TabItemType = {
+  value: any
+  onChange: (activeKey: string) => void
+  activeKey: string | null
+  activeKeyIndex: number
+  itemIndex: number
+  activeTabFlags: ActiveTabFlagsInterface
+  itemRef: React.RefObject<HTMLDivElement>
+  activeNxtRef: React.RefObject<HTMLDivElement>
+  activePrevRef: React.RefObject<HTMLDivElement>
+  dragHandle: boolean
+  dragHandleElement: React.FC<any> | null
+  readOnly: boolean
+}
+
+export type TabsListProps = {
+  items: Array<ReactNode>
+  onChange: (activeKey: string) => void
+  activeKey: string
+  activeKeyIndex: number
+  activeTabFlags: ActiveTabFlagsInterface
+  listRef: React.RefObject<HTMLDivElement>
+  itemRef: React.RefObject<HTMLDivElement>
+  activeNxtRef: React.RefObject<HTMLDivElement>
+  activePrevRef: React.RefObject<HTMLDivElement>
+  dragHandle: boolean
+  dragHandleElement: React.FC<any> | null
+  readOnly: boolean
 }

--- a/src/components/Tabs/utils.ts
+++ b/src/components/Tabs/utils.ts
@@ -1,11 +1,11 @@
-import { activeTabFlagsInterface } from "./types"
+import { ActiveTabFlagsInterface } from "./types"
 
 export const getWidthFromRef = (refNode: React.RefObject<HTMLDivElement>) => {
   return refNode.current ? refNode.current.offsetWidth : 0
 }
 
 export const getTabContainerStyle = (
-  activeTabFlags: activeTabFlagsInterface,
+  activeTabFlags: ActiveTabFlagsInterface,
   activeKeyIndex: number,
   itemIndex: number,
   itemRef: React.RefObject<HTMLDivElement>


### PR DESCRIPTION
- Sticky property fix caused due to it's container & scroller element were different
- Blur Elements on left or right of active tab to indicate hidden tabs